### PR TITLE
Fix click context

### DIFF
--- a/rcore/buttons.c
+++ b/rcore/buttons.c
@@ -382,3 +382,12 @@ void button_unsubscribe_all(void)
         memset(holder, 0, sizeof(ClickConfig));
     }
 }
+
+void button_set_click_context(ButtonId button_id, void *context)
+{
+    if (button_id >= NUM_BUTTONS)
+        return;
+
+    _button_holders[button_id]->click_config.context = context;
+}
+

--- a/rcore/buttons.h
+++ b/rcore/buttons.h
@@ -38,3 +38,5 @@ void button_raw_click_subscribe(ButtonId button_id, ClickHandler down_handler, C
 void button_unsubscribe_all(void);
 
 ButtonHolder *button_add_click_config(ButtonId button_id, ClickConfig click_config);
+
+void button_set_click_context(ButtonId button_id, void *context);

--- a/rwatch/ui/window.c
+++ b/rwatch/ui/window.c
@@ -160,6 +160,7 @@ void window_raw_click_subscribe(ButtonId button_id, ClickHandler down_handler, C
 
 void window_set_click_context(ButtonId button_id, void *context)
 {
+    button_set_click_context(button_id, context);
 }
 
 

--- a/rwatch/ui/window.c
+++ b/rwatch/ui/window.c
@@ -179,6 +179,8 @@ void rbl_window_load_proc(void)
 
 void rbl_window_load_click_config(void)
 {
-    if (top_window->click_config_provider)
-        top_window->click_config_provider(top_window);
+    if (top_window->click_config_provider) {
+        void* context = top_window->click_config_context ? top_window->click_config_context : top_window;
+        top_window->click_config_provider(context);
+    }
 }


### PR DESCRIPTION
Implemented `window_set_click_context` and fixed click config provider context, calling provider with previously registered context.