### PR TITLE
Add basic scrolling in ScrollLayer

### DIFF
--- a/rwatch/ui/layer/layer.h
+++ b/rwatch/ui/layer/layer.h
@@ -59,6 +59,6 @@ bool layer_get_clips(const Layer *layer); //TODO
 void *layer_get_data(const Layer *layer); //TODO
 
 
-void walk_layers(/*const*/ Layer *layer);
+void walk_layers(/*const*/ Layer *layer, GContext *context);
 void layer_delete_tree(Layer *layer);
 

--- a/rwatch/ui/layer/scroll_layer.h
+++ b/rwatch/ui/layer/scroll_layer.h
@@ -33,6 +33,9 @@ typedef struct ScrollLayer
 } ScrollLayer;
 
 
+ScrollLayer *scroll_layer_create(GRect frame);
+void scroll_layer_destroy(ScrollLayer *layer);
+Layer *scroll_layer_get_layer(ScrollLayer *scroll_layer);
 
 void scroll_layer_add_child(ScrollLayer *scroll_layer, Layer *child);
 void scroll_layer_set_click_config_onto_window(ScrollLayer *scroll_layer, struct Window *window);

--- a/rwatch/ui/window.c
+++ b/rwatch/ui/window.c
@@ -6,6 +6,7 @@
  */
 
 #include "librebble.h"
+#include "ngfxwrap.h"
 
 // TODO uh, oh. Maybe we need a linked list of windows. Check the api and infer
 Window *top_window;
@@ -80,7 +81,10 @@ Layer *window_get_root_layer(Window *window)
 void window_dirty(bool is_dirty)
 {
     top_window->is_render_scheduled = is_dirty;
-    walk_layers(top_window->root_layer);
+
+    GContext *context = rwatch_neographics_get_global_context();
+    context->offset = layer_get_frame(top_window->root_layer);
+    walk_layers(top_window->root_layer, context);
     
     // TODO: shortcut, for now just draw directly
     rbl_draw();

--- a/rwatch/utils.h
+++ b/rwatch/utils.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "pebble_defines.h"
+
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
+#define CLAMP(v, min, max) MIN(max, MAX(min, v))
+
+#define POINT_EQ(p1, p2) ((p1).x == (p2).x && (p1).y == (p2).y)
+#define SIZE_EQ(s1, s2) ((s1).w == (s2).w && (s1).h == (s2).h)
+#define RECT_EQ(r1, r2) (POINT_EQ((r1).origin, (r2).origin) && SIZE_EQ((r1).size, (r2).size))


### PR DESCRIPTION
Added basic scrolling in ScrollLayer, it handles up/down buttons to scroll content about fixed amount (without animation).
Scrolling is done by updating content `frame`.

This requires #15 to work.