### PR TITLE
Multiple notifications

### DIFF
--- a/Apps/System/notification.c
+++ b/Apps/System/notification.c
@@ -23,9 +23,12 @@ void notif_init(void)
     char *title = "Test Alert";
     char *body = "Testing a basic notification on RebbleOS. Create it using notification_window_create, with an app_name, title, body, and optional icon.";
     
-    NotificationWindow *notification_window = notification_window_create(app, title, body, gbitmap_create_with_resource(23));
+    Notification *notification = notification_create(app, title, body, gbitmap_create_with_resource(77), GColorRed);
     
-    window_stack_push_notification(notification_window);
+    window_stack_push_notification(notification);
+    
+    Notification *notification_two = notification_create("Discord", "Join Us", "Join us on the Pebble Discord in the #firmware channel", gbitmap_create_with_resource(20), GColorFromRGB(85, 0, 170));
+    window_stack_push_notification(notification_two);
 }
 
 void notif_deinit(void)

--- a/config.mk
+++ b/config.mk
@@ -100,6 +100,7 @@ SRCS_all += rwatch/ui/layer/scroll_layer.c
 SRCS_all += rwatch/ui/layer/action_bar_layer.c
 SRCS_all += rwatch/ui/layer/text_layer.c
 SRCS_all += rwatch/ui/window.c
+SRCS_all += rwatch/ui/action_menu.c
 SRCS_all += rwatch/ui/notification_window.c
 SRCS_all += rwatch/graphics/gbitmap.c
 SRCS_all += rwatch/graphics/graphics.c

--- a/rwatch/ui/action_menu.c
+++ b/rwatch/ui/action_menu.c
@@ -1,0 +1,262 @@
+/* action_menu.c
+ *
+ * A tiered menu
+ *
+ * RebbleOS
+ * 
+ * Author: Carson Katri <me@carsonkatri.com>.
+ */
+
+#include "rebbleos.h"
+#include "action_menu.h"
+
+/* STRUCT DEFS */
+struct ActionMenuLevel
+{
+    ActionMenuLevelDisplayMode *display_mode;
+    ActionMenuItem *items;
+    int count;
+    uint16_t *capacity;
+    int index;
+};
+
+struct ActionMenuItem
+{
+    ActionMenuLevel *level;
+    char *label;
+    void *action_data;
+    ActionMenuPerformActionCb cb;
+};
+
+struct ActionMenu
+{
+    ActionMenuConfig *config;
+    int *level_index;
+    Window *result_window;
+    MenuLayer *menu_layer;
+};
+
+/* END */
+
+char * action_menu_item_get_label(const ActionMenuItem * item)
+{
+    return item->label;
+}
+
+void * action_menu_item_get_action_data(const ActionMenuItem * item)
+{
+    return item->action_data;
+}
+
+ActionMenuLevel * action_menu_level_create(uint16_t max_items)
+{
+    ActionMenuLevel *level = (ActionMenuLevel *) calloc(1, sizeof(ActionMenuLevel) + (sizeof(ActionMenuItem) * max_items));
+    level->capacity = max_items;
+    level->count = 0;
+    level->index = 0;
+    
+    return level;
+}
+
+void action_menu_level_set_display_mode(ActionMenuLevel * level, ActionMenuLevelDisplayMode display_mode)
+{
+    level->display_mode = (ActionMenuLevelDisplayMode *) display_mode;
+}
+
+ActionMenuItem * action_menu_level_add_action(ActionMenuLevel * level, const char *label, ActionMenuPerformActionCb cb, void * action_data)
+{
+    ActionMenuItem *items = level->items;
+    
+    ActionMenuItem *new_item = (ActionMenuItem *) calloc(1, sizeof(ActionMenuItem));
+    new_item->label = label;
+    new_item->level = level;
+    new_item->cb = cb;
+    new_item->action_data = action_data;
+    
+    if (level->capacity == level->count)
+        return NULL;
+    
+    items[level->count++] = *new_item;
+    return new_item;
+}
+
+static void child_level_action_performed_callback(ActionMenu *action_menu, const ActionMenuItem *action, void *context)
+{
+    // Switch levels
+    action_menu->level_index += 1;
+}
+
+ActionMenuItem * action_menu_level_add_child(ActionMenuLevel * level, ActionMenuLevel * child, const char * label)
+{
+    return action_menu_level_add_action(level, label, child_level_action_performed_callback, child);
+}
+
+void action_menu_hierarchy_destroy(const ActionMenuLevel * root, ActionMenuEachItemCb each_cb, void * context)
+{
+    free(root->display_mode);
+    free(root->items);
+    
+    free(root);
+}
+
+void * action_menu_get_context(ActionMenu * action_menu)
+{
+    return action_menu->config->context;
+}
+
+ActionMenuLevel * action_menu_get_root_level(ActionMenu * action_menu)
+{
+    return action_menu->config->root_level;
+}
+
+static void side_bar_update_proc(Layer *layer, GContext *nGContext)
+{
+    ActionMenu *action_menu = (ActionMenu *) layer->container;
+    ActionMenuConfig *config = action_menu->config;
+    
+#ifdef PBL_RECT
+    // Draw the sidebar:
+    graphics_context_set_fill_color(nGContext, config->colors.background);
+    graphics_fill_rect_app(nGContext, GRect(0, 0, layer->frame.size.w, layer->frame.size.h), 0, GCornerNone);
+    
+    // Draw the level:
+    int index = action_menu->level_index;
+    SYS_LOG("notification_window", APP_LOG_LEVEL_DEBUG, "INDEX: %d", index);
+    graphics_context_set_fill_color(nGContext, GColorWhite);
+    n_graphics_fill_circle(nGContext, GPoint(layer->frame.size.w / 2, (10 * (index + 1)) + (5 * index)), 4);
+#else
+    // On round, just draw a circle around the menu
+    graphics_context_set_stroke_color(nGContext, config->colors.background);
+    nGContext->stroke_width = 13;
+    n_graphics_draw_circle(nGContext, GPoint(DISPLAY_COLS / 2, DISPLAY_ROWS / 2), (DISPLAY_COLS / 2) - 5);
+#endif
+}
+
+static uint16_t get_num_rows_callback(MenuLayer *menu_layer,
+                                      uint16_t section_index, void *context) {
+    ActionMenu *action_menu = (ActionMenu *) context;
+    const uint16_t num_rows = 3;
+    return num_rows;
+}
+
+static void draw_row_callback(GContext *ctx, const Layer *cell_layer,
+                              MenuIndex *cell_index, void *context) {
+    GRect frame = cell_layer->frame;
+    ActionMenu *action_menu = (ActionMenu *) context;
+    
+    // Draw this row's index
+    ctx->text_color = GColorWhite;
+    
+    const char *item_text = &action_menu->config->root_level->items[cell_index->row].label;
+    
+#ifdef PBL_RECT
+    GTextAlignment align = GTextAlignmentLeft;
+    GFont item_font = fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD);
+    GRect item_rect = GRect(30, frame.size.h / 2 - 16, frame.size.w - 35, 24);
+    graphics_draw_text_app(ctx, item_text, item_font, item_rect, GTextOverflowModeTrailingEllipsis, align, 0);
+#else
+    GTextAlignment align = GTextAlignmentCenter;
+    GFont item_font = fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD);
+    GRect item_rect = GRect(20, frame.size.h / 2 - 16, frame.size.w - 25, 24);
+    graphics_draw_text_app(ctx, item_text, item_font, item_rect, GTextOverflowModeTrailingEllipsis, align, 0);
+#endif
+}
+
+static int16_t get_cell_height_callback(struct MenuLayer *menu_layer,
+                                        MenuIndex *cell_index, void *context) {
+#ifdef PBL_RECT
+    const int16_t cell_height = 44;
+#else
+    const int16_t cell_height = 180;
+#endif
+    return cell_height;
+}
+
+static void item_selected(struct MenuLayer *menu_layer,
+                            MenuIndex *cell_index, void *context) {
+    // Do something in response to the button press
+}
+
+static void action_menu_window_load(Window *window)
+{
+    ActionMenu *action_menu = (ActionMenu *) window->user_data;
+    ActionMenuConfig *config = action_menu->config;
+    
+    // Make a menu
+    GRect frame = layer_get_unobstructed_bounds(window_get_root_layer(window));
+    action_menu->menu_layer = menu_layer_create(frame);
+    menu_layer_set_callbacks(action_menu->menu_layer, NULL, (MenuLayerCallbacks) {
+        .get_num_rows = get_num_rows_callback,
+        .draw_row = draw_row_callback,
+        .get_cell_height = get_cell_height_callback,
+        .select_click = item_selected
+    });
+    layer_add_child(window_get_root_layer(window), menu_layer_get_layer(action_menu->menu_layer));
+    
+    action_menu->menu_layer->bg_color = GColorBlack;
+    action_menu->menu_layer->bg_hi_color = GColorBlack;
+    action_menu->menu_layer->fg_hi_color = GColorWhite;
+    action_menu->menu_layer->fg_color = GColorWhite;
+    
+    //menu_layer_set_click_config_provider(action_menu->menu_layer, (ClickConfigProvider) menu_click_config_provider);
+    menu_layer_set_click_config_onto_window(action_menu->menu_layer, window);
+    
+    action_menu->menu_layer->context = action_menu;
+#ifdef PBL_RECT
+    Layer *side_bar_layer = layer_create(GRect(0, 0, 20, DISPLAY_ROWS));
+#else
+    Layer *side_bar_layer = layer_create(GRect(0, 0, DISPLAY_COLS, DISPLAY_ROWS));
+#endif
+    side_bar_layer->container = action_menu;
+    layer_set_update_proc(side_bar_layer, side_bar_update_proc);
+    
+    layer_add_child(window_get_root_layer(window), side_bar_layer);
+    
+    layer_mark_dirty(menu_layer_get_layer(action_menu->menu_layer));
+}
+
+static void action_menu_window_unload(Window *window)
+{
+    // Unloaded
+}
+
+ActionMenu * action_menu_open(ActionMenuConfig * config)
+{
+    ActionMenu *action_menu = (ActionMenu *) calloc(1, sizeof(ActionMenu));
+    action_menu->config = config;
+    action_menu->level_index = 0;
+    
+    Window *main = window_create();
+    main->user_data = action_menu;
+    
+    window_set_window_handlers(main, (WindowHandlers) {
+        .load = action_menu_window_load,
+        .unload = action_menu_window_unload,
+    });
+    
+    window_stack_push(main, true);
+    
+    app_event_loop();
+    
+    return action_menu;
+}
+
+void action_menu_freeze(ActionMenu * action_menu)
+{
+    
+}
+
+void action_menu_unfreeze(ActionMenu * action_menu)
+{
+    
+}
+
+void action_menu_set_result_window(ActionMenu * action_menu, Window * result_window)
+{
+    action_menu->result_window = result_window;
+}
+
+void action_menu_close(ActionMenu * action_menu, bool animated)
+{
+    
+}

--- a/rwatch/ui/action_menu.h
+++ b/rwatch/ui/action_menu.h
@@ -1,0 +1,132 @@
+#pragma once
+/* action_menu.h
+ *
+ * A tiered menu.
+ *
+ * RebbleOS
+ *
+ * Author: Carson Katri <me@carsonkatri.com>.
+ */
+
+#include "librebble.h"
+#include "menu_layer.h"
+
+struct ActionMenuLevel;
+typedef struct ActionMenuLevel ActionMenuLevel;
+
+struct ActionMenuItem;
+typedef struct ActionMenuItem ActionMenuItem;
+
+struct ActionMenu;
+typedef struct ActionMenu ActionMenu;
+
+typedef enum ActionMenuLevelDisplayMode
+{
+    ActionMenuAlignTop = 0,
+    ActionMenuAlignCenter = 1
+} ActionMenuAlign;
+
+typedef enum
+{
+    ActionMenuLevelDisplayModeWide = 0, // ROWS
+    ActionMenuLevelDisplayModeThin = 1 // GRIDED
+} ActionMenuLevelDisplayMode;
+
+typedef void(* ActionMenuDidCloseCb)(ActionMenu *menu, const ActionMenuItem *performed_action, void *context);
+typedef void(* ActionMenuPerformActionCb)(ActionMenu *action_menu, const ActionMenuItem *action, void *context);
+typedef void(* ActionMenuEachItemCb)(const ActionMenuItem *item, void *context);
+
+typedef struct ActionMenuConfig
+{
+    const ActionMenuLevel *root_level;
+    void *context;
+    struct
+    {
+        GColor background; // Left column
+        GColor foreground; // Dots
+    } colors;
+    ActionMenuDidCloseCb will_close;
+    ActionMenuDidCloseCb did_close;
+    ActionMenuAlign align;
+} ActionMenuConfig;
+
+char * action_menu_item_get_label(const ActionMenuItem * item);
+
+void * action_menu_item_get_action_data(const ActionMenuItem * item);
+
+ActionMenuLevel * action_menu_level_create(uint16_t max_items);
+
+void action_menu_level_set_display_mode(ActionMenuLevel * level, ActionMenuLevelDisplayMode display_mode);
+
+ActionMenuItem * action_menu_level_add_action(ActionMenuLevel * level, const char *label, ActionMenuPerformActionCb cb, void * action_data);
+
+ActionMenuItem * action_menu_level_add_child(ActionMenuLevel * level, ActionMenuLevel * child, const char * label);
+
+void action_menu_hierarchy_destroy(const ActionMenuLevel * root, ActionMenuEachItemCb each_cb, void * context);
+
+void * action_menu_get_context(ActionMenu * action_menu);
+
+ActionMenuLevel * action_menu_get_root_level(ActionMenu * action_menu);
+
+ActionMenu * action_menu_open(ActionMenuConfig * config);
+
+void action_menu_freeze(ActionMenu * action_menu);
+
+void action_menu_unfreeze(ActionMenu * action_menu);
+
+void action_menu_set_result_window(ActionMenu * action_menu, Window * result_window);
+
+void action_menu_close(ActionMenu * action_menu, bool animated);
+
+/*
+struct ActionMenuItem;
+struct ActionMenuItems;
+
+typedef struct ActionMenuItems* (*ActionMenuItemCallback)(const struct ActionMenuItem *item);
+
+typedef struct ActionMenuItem
+{
+    char *text;
+    char *sub_text;
+    MenuItemCallback on_select;
+} ActionMenuItem;
+
+#define ActionMenuItem(text, sub_text, image, on_select) ((MenuItem) { text, sub_text, image, on_select })
+
+typedef struct ActionMenuItems
+{
+    uint16_t count;
+    uint16_t capacity;
+    MenuItem *items;
+    
+    struct ActionMenuItems *back;
+    ActionMenuIndex back_index;
+} ActionMenuItems;
+
+ActionMenuItems* action_menu_items_create(uint16_t capacity);
+void action_menu_items_destroy(ActionMenuItems *items);
+void action_menu_items_add(ActionMenuItems *items, ActionMenuItem item);
+
+// called when back is pressed while in top menu
+typedef void (*ActionMenuExitCallback)(struct ActionMenu *menu, void *context);
+
+typedef struct ActionMenuCallbacks
+{
+    ActionMenuExitCallback on_action_menu_exit;
+} ActionMenuCallbacks;
+
+typedef struct ActionMenu
+{
+    ActionMenuItems *items;
+    MenuLayer *layer;
+    ActionMenuCallbacks callbacks;
+    void *context;
+} ActionMenu;
+
+
+ActionMenu* action_menu_create(GRect frame);
+void menu_destroy(Menu *menu);
+void menu_set_items(Menu *menu, MenuItems *items);
+Layer* menu_get_layer(Menu *menu);
+void menu_set_callbacks(Menu *menu, void *context, MenuCallbacks callbacks);
+void menu_set_click_config_onto_window(Menu *menu, struct Window *window);*/

--- a/rwatch/ui/notification_window.h
+++ b/rwatch/ui/notification_window.h
@@ -1,24 +1,48 @@
 #pragma once
-/* window.c
- * routines for [...]
- * libRebbleOS
+/* notification_window.h
+ *
+ * Displays notifications sent to the watch from the phone.
  *
  * Author: Carson Katri <me@carsonkatri.com>
  */
 
 #include "librebble.h"
 
-typedef struct NotificationWindow
+typedef enum NotificationAction
 {
-    Window *window;
+    NotificationActionDismiss = 0,
+    NotificationActionDismissAll = 1,
+    NotificationActionReply = 2,
+    NotificationActionCustom = 3
+} NotificationAction;
+
+typedef struct NotificationWindow NotificationWindow;
+
+typedef struct Notification Notification;
+
+struct Notification
+{
     GBitmap *icon;
     const char *app_name;
     const char *title;
     const char *body;
-    int *offset;
-} NotificationWindow;
+    char *custom_actions;
+    GColor color;
+    
+    // Doubly linked list
+    Notification *next;
+    Notification *previous;
+};
 
-NotificationWindow* notification_window_create(const char *app_name, const char *title, const char *body, GBitmap *icon);
+struct NotificationWindow
+{
+    Window *window;
+    int *offset;
+    NotificationAction *actions;
+    Notification *active;
+};
+
+Notification* notification_window_create(const char *app_name, const char *title, const char *body, GBitmap *icon, GColor color);
 
 Window* notification_window_get_window(NotificationWindow *notification_window);
 


### PR DESCRIPTION
Now you create a `Notification` with `notification_create`. When you push the notification onto the notification stack, there is one `notification_window` that gets pushed to the top of the window stack.

You can now scroll between all your notifications, and each one has its own `color`.

The `Notification`s make up a doubly linked list, which switch out as `active` on the `notification_window` so they get drawn on screen.

I also added an `action_menu` which *almost* works? I still have to polish that but at least it's there and will help with support for more apps as well as the notifications.