### PR TITLE
Menu + statusbar touchups

### DIFF
--- a/Apps/System/systemapp.c
+++ b/Apps/System/systemapp.c
@@ -83,10 +83,8 @@ static void systemapp_window_load(Window *window)
 {
     printf("WF load\n");
     Layer *window_layer = window_get_root_layer(s_main_window);
-    //GRect bounds = layer_get_unobstructed_bounds(window_layer);
     
-    // TODO find out why the menu gets offset double in the y direction (x is affected too)
-    s_menu = menu_create(GRect(0, 8, DISPLAY_COLS, DISPLAY_ROWS - 16));
+    s_menu = menu_create(GRect(0, 16, DISPLAY_COLS, DISPLAY_ROWS - 16));
     menu_set_callbacks(s_menu, s_menu, (MenuCallbacks) {
         .on_menu_exit = exit_to_watchface
     });
@@ -103,10 +101,8 @@ static void systemapp_window_load(Window *window)
 
     // Status Bar
     status_bar = status_bar_layer_create();
-    layer_add_child(window_layer, status_bar_layer_get_layer(status_bar));
-    
-    // TODO: Offset the menu:
-    
+    layer_add_child(menu_get_layer(s_menu), status_bar_layer_get_layer(status_bar));
+
     //tick_timer_service_subscribe(MINUTE_UNIT, prv_tick_handler);
 }
 

--- a/Apps/System/systemapp.c
+++ b/Apps/System/systemapp.c
@@ -9,6 +9,7 @@
 #include "systemapp.h"
 #include "menu.h"
 #include "status_bar_layer.h"
+#include "platform_config.h"
 
 extern void flash_dump(void);
 
@@ -82,9 +83,10 @@ static void systemapp_window_load(Window *window)
 {
     printf("WF load\n");
     Layer *window_layer = window_get_root_layer(s_main_window);
-    GRect bounds = layer_get_unobstructed_bounds(window_layer);
-
-    s_menu = menu_create(bounds);
+    //GRect bounds = layer_get_unobstructed_bounds(window_layer);
+    
+    // TODO find out why the menu gets offset double in the y direction (x is affected too)
+    s_menu = menu_create(GRect(0, 8, DISPLAY_COLS, DISPLAY_ROWS - 16));
     menu_set_callbacks(s_menu, s_menu, (MenuCallbacks) {
         .on_menu_exit = exit_to_watchface
     });
@@ -101,7 +103,7 @@ static void systemapp_window_load(Window *window)
 
     // Status Bar
     status_bar = status_bar_layer_create();
-    layer_add_child(menu_get_layer(s_menu), status_bar_layer_get_layer(status_bar));
+    layer_add_child(window_layer, status_bar_layer_get_layer(status_bar));
     
     // TODO: Offset the menu:
     

--- a/rwatch/ui/layer/menu_layer.c
+++ b/rwatch/ui/layer/menu_layer.c
@@ -469,7 +469,7 @@ void menu_cell_basic_draw(GContext *ctx, const Layer *layer, const char *title,
         has_subtitle = true;
         GFont font = fonts_get_system_font(FONT_KEY_GOTHIC_18);
         GRect subtitle_rect;
-        subtitle_rect = GRect(x, 20, frame.size.w - x - 5, 18);
+        subtitle_rect = GRect(x, 24, frame.size.w - x - 5, 18);
         graphics_draw_text_app(ctx, subtitle, font, subtitle_rect,
                                GTextOverflowModeTrailingEllipsis, align, 0);
     }
@@ -477,7 +477,7 @@ void menu_cell_basic_draw(GContext *ctx, const Layer *layer, const char *title,
     if (title)
     {
         GFont title_font = fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD);
-        GRect title_rect = GRect(x, has_subtitle ? - 3 : frame.size.h / 2 - 16, frame.size.w - x - 5, 24);
+        GRect title_rect = GRect(x, has_subtitle ? 0 : frame.size.h / 2 - 16, frame.size.w - x - 5, 24);
         graphics_draw_text_app(ctx, title, title_font, title_rect, GTextOverflowModeTrailingEllipsis,
                                align, 0);
     }

--- a/rwatch/ui/layer/menu_layer.c
+++ b/rwatch/ui/layer/menu_layer.c
@@ -227,7 +227,7 @@ void menu_layer_reload_data(MenuLayer *menu_layer)
 
     // generate cells
     size_t cell = 0;
-    int16_t y = 16; // STATUS_BAR_LAYER_HEIGHT
+    int16_t y = 0;
     int16_t h = 0;
     for (uint16_t section = 0; section < sections; ++section)
     {

--- a/rwatch/ui/layer/menu_layer.c
+++ b/rwatch/ui/layer/menu_layer.c
@@ -21,7 +21,7 @@ MenuLayer *menu_layer_create(GRect frame)
 {
     MenuLayer *mlayer = (MenuLayer *) calloc(1, sizeof(MenuLayer));
     mlayer->layer = layer_create(frame);
-    mlayer->scroll_layer = scroll_layer_create(frame);
+    mlayer->scroll_layer = scroll_layer_create(GRect(0, 0, frame.size.w, frame.size.h));
     mlayer->layer->container = mlayer;
 
     mlayer->cells_count = 0;

--- a/rwatch/ui/layer/menu_layer.c
+++ b/rwatch/ui/layer/menu_layer.c
@@ -227,7 +227,7 @@ void menu_layer_reload_data(MenuLayer *menu_layer)
 
     // generate cells
     size_t cell = 0;
-    int16_t y = 0;
+    int16_t y = 16; // STATUS_BAR_LAYER_HEIGHT
     int16_t h = 0;
     for (uint16_t section = 0; section < sections; ++section)
     {
@@ -469,7 +469,7 @@ void menu_cell_basic_draw(GContext *ctx, const Layer *layer, const char *title,
         has_subtitle = true;
         GFont font = fonts_get_system_font(FONT_KEY_GOTHIC_18);
         GRect subtitle_rect;
-        subtitle_rect = GRect(x, 24, frame.size.w - x - 5, 18);
+        subtitle_rect = GRect(x, 20, frame.size.w - x - 5, 18);
         graphics_draw_text_app(ctx, subtitle, font, subtitle_rect,
                                GTextOverflowModeTrailingEllipsis, align, 0);
     }
@@ -477,7 +477,7 @@ void menu_cell_basic_draw(GContext *ctx, const Layer *layer, const char *title,
     if (title)
     {
         GFont title_font = fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD);
-        GRect title_rect = GRect(x, has_subtitle ? 0 : frame.size.h / 2 - 16, frame.size.w - x - 5, 24);
+        GRect title_rect = GRect(x, has_subtitle ? - 3 : frame.size.h / 2 - 16, frame.size.w - x - 5, 24);
         graphics_draw_text_app(ctx, title, title_font, title_rect, GTextOverflowModeTrailingEllipsis,
                                align, 0);
     }

--- a/rwatch/ui/layer/status_bar_layer.c
+++ b/rwatch/ui/layer/status_bar_layer.c
@@ -41,8 +41,8 @@ StatusBarLayer *status_bar_layer_create(void)
     
     layer_set_update_proc(layer, draw);
     
-    tick_timer_service_subscribe(SECOND_UNIT, status_tick);
-    
+    tick_timer_service_subscribe(MINUTE_UNIT, status_tick);
+
     layer_mark_dirty(layer);
     
     return status_bar;
@@ -95,8 +95,8 @@ static void draw(Layer *layer, GContext *context)
     
     char time_string[8] = "";
     
-    printf("%d:%d", s_last_time.hours, s_last_time.minutes);
-    snprintf(time_string, 8, "%d:%d", s_last_time.hours, s_last_time.minutes);
+    printf("%d:%02d", s_last_time.hours, s_last_time.minutes);
+    snprintf(time_string, 8, "%d:%02d", s_last_time.hours, s_last_time.minutes);
     
     GRect text_bounds = GRect((full_bounds.size.w / 2) - 10, 0, 100, 10);
     graphics_draw_text_app(context, time_string, time_font, text_bounds, GTextOverflowModeTrailingEllipsis, n_GTextAlignmentLeft, 0);


### PR DESCRIPTION
Add leading 0 to statusbar minutes, change time update interval to one
minute.

Push menu down so the statusbar doesn't draw over it and move the menu
items title & subtitle so they are centered and not cut off at the bottom.