### PR TITLE
Fix chalk menu scroll behaviour

### DIFF
--- a/Apps/System/systemapp.c
+++ b/Apps/System/systemapp.c
@@ -83,8 +83,12 @@ static void systemapp_window_load(Window *window)
 {
     printf("WF load\n");
     Layer *window_layer = window_get_root_layer(s_main_window);
-    
+#ifdef PBL_RECT
     s_menu = menu_create(GRect(0, 16, DISPLAY_COLS, DISPLAY_ROWS - 16));
+#else
+    // Let the menu draw behind the statusbar so it is perfectly centered
+    s_menu = menu_create(GRect(0, 0, DISPLAY_COLS, DISPLAY_ROWS));
+#endif
     menu_set_callbacks(s_menu, s_menu, (MenuCallbacks) {
         .on_menu_exit = exit_to_watchface
     });

--- a/lib/neographics/src/types/colors.h
+++ b/lib/neographics/src/types/colors.h
@@ -25,10 +25,10 @@
 #define n_GColorWhiteARGB8                 ((uint8_t)   0b11111111)
 #define n_GColorWhite                      ((n_GColor) { .argb = (n_GColorWhiteARGB8) })
 
-#define n_GColorLightGrayARGB8             ((uint8_t)   0b11101010)
+#define n_GColorLightGrayARGB8             ((uint8_t)   0b11010101)
 #define n_GColorLightGray                  ((n_GColor) { .argb = (n_GColorLightGrayARGB8) })
 
-#define n_GColorDarkGrayARGB8              ((uint8_t)   0b11010101)
+#define n_GColorDarkGrayARGB8              ((uint8_t)   0b11101010)
 #define n_GColorDarkGray                   ((n_GColor) { .argb = (n_GColorDarkGrayARGB8) })
 
 #define n_GColorBlackARGB8                 ((uint8_t)   0b11000000)

--- a/rwatch/ui/layer/menu_layer.c
+++ b/rwatch/ui/layer/menu_layer.c
@@ -118,6 +118,7 @@ static void scroll_to_visible(MenuLayer *menu_layer, int16_t y_position, bool an
 {
     GSize size = layer_get_frame(menu_layer->layer).size;
     GPoint offset = scroll_layer_get_content_offset(menu_layer->scroll_layer);
+#ifdef PBL_RECT
     if (y_position + offset.y - (size.h) / 4  < 0)
     {
         offset.y += (size.h) / 4;
@@ -125,6 +126,15 @@ static void scroll_to_visible(MenuLayer *menu_layer, int16_t y_position, bool an
     {
         offset.y = size.h - y_position - (size.h) / 4;
     }
+#else
+    if (y_position + offset.y < 0)
+    {
+        offset.y += size.h;
+    } else if (y_position + offset.y >= size.h)
+    {
+        offset.y = size.h - y_position;
+    }
+#endif
     scroll_layer_set_content_offset(menu_layer->scroll_layer, offset, animated);
 }
 
@@ -248,7 +258,7 @@ void menu_layer_reload_data(MenuLayer *menu_layer)
                 //: 44;
             h = layer_get_frame(menu_layer->layer).size.h / 4;
 #else
-            h = 180;
+            h = layer_get_frame(menu_layer->layer).size.h;
 #endif
             menu_layer->cells[cell++] = MenuRow(section, row, y, h);
             y += h;

--- a/rwatch/ui/layer/status_bar_layer.c
+++ b/rwatch/ui/layer/status_bar_layer.c
@@ -10,6 +10,7 @@
 #include "status_bar_layer.h"
 #include "bitmap_layer.h"
 #include "graphics.h"
+#include "platform.h"
 
 typedef struct {
     int hours;
@@ -29,14 +30,14 @@ StatusBarLayer *status_bar_layer_create(void)
 {
     StatusBarLayer *status_bar = (StatusBarLayer*)app_calloc(1, sizeof(StatusBarLayer));
     
-    GRect frame = GRect(0, 0, 144, STATUS_BAR_LAYER_HEIGHT);
+    GRect frame = GRect(0, 0, DISPLAY_COLS, STATUS_BAR_LAYER_HEIGHT);
     
     Layer* layer = layer_create(frame);
     // give the layer a reference back to us
     layer->container = status_bar;
     status_bar->layer = layer;
-    status_bar->background_color = GColorWhite;
-    status_bar->text_color = GColorBlack;
+    status_bar->background_color = GColorDarkGray;
+    status_bar->text_color = GColorWhite;
     status_bar->separator_mode = StatusBarLayerSeparatorModeDotted;
     
     layer_set_update_proc(layer, draw);


### PR DESCRIPTION
This commit also changes the status bar color to light gray, whilst also
redefining the color light gray as it was swapped with dark gray.

The change of the status bar color is for letting the background be
visible on chalk so you can see that the time is missing there.
Also I think it looks rather nice aswell