### PR TITLE
Add strftime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/pbl_strftime"]
+	path = lib/pbl_strftime
+	url = git://github.com/Helco/pbl_strftime.git

--- a/config.mk
+++ b/config.mk
@@ -12,6 +12,7 @@ CFLAGS_all += -Ilib/neographics/src/fonts
 CFLAGS_all += -Ilib/neographics/src/text
 CFLAGS_all += -Ilib/minilib/inc
 CFLAGS_all += -Ilib/png
+CFLAGS_all += -Ilib/pbl_strftime/src
 CFLAGS_all += -IWatchfaces
 CFLAGS_all += -IApps
 CFLAGS_all += -IApps/System
@@ -70,6 +71,8 @@ SRCS_all += lib/neographics/src/text/text.c
 
 SRCS_all += lib/png/png.c
 SRCS_all += lib/png/upng.c
+
+SRCS_all += lib/pbl_strftime/src/strftime.c
 
 SRCS_all += rcore/ambient.c
 SRCS_all += rcore/appmanager.c

--- a/rcore/rebble_time.c
+++ b/rcore/rebble_time.c
@@ -6,6 +6,7 @@
  */
 
 #include "rebbleos.h"
+#include "strftime.h"
 
 static TickType_t _boot_ticks;
 static time_t _boot_time_t;
@@ -43,6 +44,10 @@ TickType_t rcore_time_to_ticks(time_t t, uint16_t ms) {
     if (t < _boot_time_t)
         return 0;
     return (t - _boot_time_t) * configTICK_RATE_HZ + pdMS_TO_TICKS(ms);
+}
+
+size_t rcore_strftime(char* buffer, size_t maxSize, const char* format, const struct tm* tm) {
+    return strftime(buffer, maxSize, format, tm);
 }
 
 /*

--- a/rcore/rebble_time.h
+++ b/rcore/rebble_time.h
@@ -25,6 +25,7 @@ time_t rcore_mktime(struct tm *tm);
 void rcore_localtime(struct tm *tm, time_t time);
 void rcore_time_ms(time_t *tutc, uint16_t *ms);
 TickType_t rcore_time_to_ticks(time_t t, uint16_t ms);
+size_t rcore_strftime(char* buffer, size_t maxSize, const char* format, const struct tm* tm);
 
 // private
 struct tm *rebble_time_get_tm(void);

--- a/rwatch/ui/layer/status_bar_layer.c
+++ b/rwatch/ui/layer/status_bar_layer.c
@@ -12,18 +12,12 @@
 #include "graphics.h"
 #include "platform.h"
 
-typedef struct {
-    int hours;
-    int minutes;
-} Time;
-
-static Time s_last_time;
+static struct tm s_last_time;
 
 static void status_tick(struct tm *tick_time, TimeUnits tick_units)
 {
     // Store time
-    s_last_time.hours = tick_time->tm_hour % 12;
-    s_last_time.minutes = tick_time->tm_min;
+    memcpy(&s_last_time, tick_time, sizeof(struct tm));
 }
 
 StatusBarLayer *status_bar_layer_create(void)
@@ -96,8 +90,8 @@ static void draw(Layer *layer, GContext *context)
     
     char time_string[8] = "";
     
-    printf("%d:%02d", s_last_time.hours, s_last_time.minutes);
-    snprintf(time_string, 8, "%d:%02d", s_last_time.hours, s_last_time.minutes);
+    rcore_strftime(time_string, 8, "%R", &s_last_time);
+    printf("%s", time_string);
     
     GRect text_bounds = GRect((full_bounds.size.w / 2) - 10, 0, 100, 10);
     graphics_draw_text_app(context, time_string, time_font, text_bounds, GTextOverflowModeTrailingEllipsis, n_GTextAlignmentLeft, 0);


### PR DESCRIPTION
Fixes pebble-dev/RebbleOS#16
The implementation was orientated on [newlib documentation](https://sourceware.org/newlib/libc.html#strftime).
It does not touch pebble-dev/RebbleOS#11 but integrating something like gettext should be easy.