### PR TITLE
Fix property_animation

### DIFF
--- a/rwatch/ui/animation/animation.c
+++ b/rwatch/ui/animation/animation.c
@@ -31,8 +31,13 @@ Animation *animation_create()
     SYS_LOG("animation", APP_LOG_LEVEL_INFO, "animation_create");
     
     Animation *anim = app_calloc(1, sizeof(Animation));
+    animation_ctor(anim);
     
     return anim;
+}
+
+void animation_ctor(Animation* animation)
+{
 }
 
 bool animation_destroy(Animation *anim)
@@ -40,9 +45,14 @@ bool animation_destroy(Animation *anim)
     if (!anim)
         return false;
     
+    animation_dtor(anim);
     app_free(anim);
     
     return true;
+}
+
+void animation_dtor(Animation* animation)
+{
 }
 
 void _animation_update(Animation *anim)
@@ -75,7 +85,7 @@ void _animation_update(Animation *anim)
     progress /= anim->duration;
     
     if (anim->impl.update)
-        anim->impl.update(anim->property_anim != NULL ? anim->property_anim : anim, (uint32_t) progress);
+        anim->impl.update(anim, (uint32_t) progress);
     
     anim->onqueue = 1;
     appmanager_timer_add(&anim->timer);

--- a/rwatch/ui/animation/animation.h
+++ b/rwatch/ui/animation/animation.h
@@ -59,8 +59,6 @@ typedef struct Animation
     TickType_t startticks;
     AnimationImplementation impl;
     struct AnimationHandler *anim_handlers;
-    
-    PropertyAnimation *property_anim;
 } Animation;
 
 typedef struct AnimationHandler
@@ -74,7 +72,9 @@ typedef AnimationProgress(* AnimationCurveFunction)(AnimationProgress linear_dis
 
 // animation
 Animation *animation_create();
+void animation_ctor(Animation* animation);
 bool animation_destroy(Animation *animation);
+void animation_dtor(Animation* animation);
 Animation *animation_clone(Animation *from);
 Animation *animation_sequence_create(Animation *animation_a, Animation *animation_b, Animation *animation_c, ...);
 Animation *animation_sequence_create_from_array(Animation ** animation_array, uint32_t array_len);

--- a/rwatch/ui/animation/property_animation.h
+++ b/rwatch/ui/animation/property_animation.h
@@ -60,7 +60,7 @@ typedef struct PropertyAnimationImplementation
 
 typedef struct PropertyAnimation
 {
-    Animation *animation;
+    Animation animation;
     struct
     {
         void *from;

--- a/rwatch/ui/layer/layer.c
+++ b/rwatch/ui/layer/layer.c
@@ -125,6 +125,18 @@ GPoint layer_convert_point_to_screen(const Layer *layer, GPoint point)
     return point;
 }
 
+GPoint layer_get_bounds_origin(Layer* layer)
+{
+    return layer->bounds.origin;
+}
+
+void layer_set_bounds_origin(Layer* layer, GPoint origin) {
+    if (!POINT_EQ(layer->bounds.origin, origin)) {
+        layer->bounds.origin = origin;
+        layer_mark_dirty(layer);
+    }
+}
+
 void layer_set_frame(Layer *layer, GRect frame)
 {
     if (!RECT_EQ(layer->frame, frame)) {

--- a/rwatch/ui/layer/layer.h
+++ b/rwatch/ui/layer/layer.h
@@ -46,6 +46,9 @@ void layer_add_child(Layer *parent_layer, Layer *child_layer);
 void layer_mark_dirty(Layer *layer);
 GRect layer_get_bounds(Layer *layer);
 GPoint layer_convert_point_to_screen(const Layer *layer, GPoint point);
+GPoint layer_get_bounds_origin(Layer* layer); // Not in the original API, but necessary for property_animation
+void layer_set_bounds_origin(Layer* layer, GPoint origin);
+GPoint layer_convert_point_to_screen(const Layer *layer, GPoint point); //TODO
 GRect layer_convert_rect_to_screen(const Layer *layer, GRect rect); //TODO
 struct Window *layer_get_window(const Layer *layer);
 void layer_remove_from_parent(Layer *child);


### PR DESCRIPTION
While working on fixes for `menu_layer` I stumbled across those bugs:

- `property_animation` uses a hacky way to map an animation pointer to itself. Regarding to old `pebble.h` files, the Pebble team used an inheritance-style pattern, which I recreated.
This is also supported by the fact that `property_animation_update_*` take a pointer to the own structure, but shall be compatible with `AnimationUpdateImplementation`
- this hack had to be put into `animation.c` to work somewhat, but the teardown update was forgotten. This is no longer needed.
- `property_animation` used the last value set to calculate the new value instead of the actual `from` value. In a longer animation we should have observed a ease-in curve without the actual implementation for it :)
- `property_animation_create_layer_bounds_origin` used `layer_[gs]et_bounds` as accessor functions which return/set `GRect` instead of `GPoint`

I introduced a new concept, which should be discussed: `ctor` and `dtor` functions for classes which work with an object without allocating/freeing memory for it, this is to support the inheritance. For the case of `animation` this is not actually needed, as the `create/destroy` function does not do anything but managing the memory. Perhaps these additional functions should only be created when they contain some logic.
