### PR TITLE
Add simple_menu_layer

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -102,6 +102,7 @@ SRCS_all += rwatch/math_sin.c
 SRCS_all += rwatch/ui/layer/layer.c
 SRCS_all += rwatch/ui/layer/bitmap_layer.c
 SRCS_all += rwatch/ui/layer/menu_layer.c
+SRCS_all += rwatch/ui/layer/simple_menu_layer.c
 SRCS_all += rwatch/ui/layer/scroll_layer.c
 SRCS_all += rwatch/ui/layer/action_bar_layer.c
 SRCS_all += rwatch/ui/layer/text_layer.c

--- a/rwatch/ui/layer/simple_menu_layer.c
+++ b/rwatch/ui/layer/simple_menu_layer.c
@@ -9,32 +9,38 @@
 #include "simple_menu_layer.h"
 #include "menu_layer.h"
 
-static uint16_t prv_simple_menu_get_number_of_sections(struct MenuLayer* menu_layer, void* callback_context) {
+static uint16_t _get_number_of_sections(struct MenuLayer *menu_layer, void *callback_context)
+{
     SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
     return simple_menu->num_sections;
 }
 
-static uint16_t prv_simple_menu_get_number_of_rows_in_section(struct MenuLayer* menu_layer, uint16_t section_index, void* callback_context) {
+static uint16_t _get_number_of_rows_in_section(struct MenuLayer *menu_layer, uint16_t section_index, void *callback_context)
+{
     SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
     return simple_menu->sections[section_index].num_items;
 }
 
-static int16_t prv_simple_menu_get_cell_height(struct MenuLayer* menu_layer, MenuIndex* cell_index, void* callback_context) {
+static int16_t _get_cell_height(struct MenuLayer *menu_layer, MenuIndex *cell_index, void *callback_context)
+{
     return MENU_CELL_BASIC_CELL_HEIGHT;
 }
 
-static int16_t prv_simple_menu_get_header_height(struct MenuLayer* menu_layer, uint16_t section_index, void* callback_context) {
+static int16_t _get_header_height(struct MenuLayer *menu_layer, uint16_t section_index, void *callback_context)
+{
     SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
     return simple_menu->sections[section_index].title == NULL ? 0 : MENU_CELL_BASIC_HEADER_HEIGHT;
 }
 
-static void prv_simple_menu_draw_row(GContext* ctx, const Layer* cell_layer, MenuIndex* cell_index, void* callback_context) {
+static void _draw_row(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_index, void *callback_context)
+{
     SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
     const SimpleMenuItem* item = &simple_menu->sections[cell_index->section].items[cell_index->row];
     menu_cell_basic_draw(ctx, cell_layer, item->title, item->subtitle, item->icon);
 }
 
-static void prv_simple_menu_draw_header(GContext* ctx, const Layer* cell_layer, uint16_t section_index, void* callback_context) {
+static void _draw_header(GContext *ctx, const Layer *cell_layer, uint16_t section_index, void *callback_context)
+{
     SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
     const SimpleMenuSection* section = &simple_menu->sections[section_index];
     if (section->title != NULL) {
@@ -42,15 +48,16 @@ static void prv_simple_menu_draw_header(GContext* ctx, const Layer* cell_layer, 
     }
 }
 
-static void prv_simple_menu_select(struct MenuLayer* menu_layer, MenuIndex* cell_index, void* callback_context) {
+static void _select(struct MenuLayer *menu_layer, MenuIndex *cell_index, void *callback_context)
+{
     SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
     const SimpleMenuItem* item = &simple_menu->sections[cell_index->section].items[cell_index->row];
     if (item->callback)
         item->callback(cell_index->row, simple_menu->callback_context);
 }
 
-SimpleMenuLayer* simple_menu_layer_create(GRect frame, struct Window* window, const SimpleMenuSection* sections,
-                                          int32_t num_sections, void* callback_context)
+SimpleMenuLayer* simple_menu_layer_create(GRect frame, struct Window *window, const SimpleMenuSection *sections,
+                                          int32_t num_sections, void *callback_context)
 {
     SimpleMenuLayer* simple_menu = app_calloc(1, sizeof(SimpleMenuLayer));
     simple_menu->sections = sections;
@@ -61,13 +68,13 @@ SimpleMenuLayer* simple_menu_layer_create(GRect frame, struct Window* window, co
     simple_menu->menu_layer = menu_layer;
     menu_layer_set_click_config_onto_window(menu_layer, window);
     menu_layer_set_callbacks(menu_layer, simple_menu, (MenuLayerCallbacks){
-        .get_num_sections = prv_simple_menu_get_number_of_sections,
-        .get_num_rows = prv_simple_menu_get_number_of_rows_in_section,
-        .get_cell_height = prv_simple_menu_get_cell_height,
-        .get_header_height = prv_simple_menu_get_header_height,
-        .draw_row = prv_simple_menu_draw_row,
-        .draw_header = prv_simple_menu_draw_header,
-        .select_click = prv_simple_menu_select,
+        .get_num_sections = _get_number_of_sections,
+        .get_num_rows = _get_number_of_rows_in_section,
+        .get_cell_height = _get_cell_height,
+        .get_header_height = _get_header_height,
+        .draw_row = _draw_row,
+        .draw_header = _draw_header,
+        .select_click = _select,
         .select_long_click = NULL,
         .selection_changed = NULL,
         .get_separator_height = NULL,
@@ -78,24 +85,24 @@ SimpleMenuLayer* simple_menu_layer_create(GRect frame, struct Window* window, co
     return simple_menu;
 }
 
-void simple_menu_layer_destroy(SimpleMenuLayer* simple_menu)
+void simple_menu_layer_destroy(SimpleMenuLayer *simple_menu)
 {
     menu_layer_destroy(simple_menu->menu_layer);
     app_free(simple_menu);
 }
 
-struct Layer* simple_menu_layer_get_layer(const SimpleMenuLayer* simple_menu)
+struct Layer* simple_menu_layer_get_layer(const SimpleMenuLayer *simple_menu)
 {
     return menu_layer_get_layer(simple_menu->menu_layer);
 }
 
-int simple_menu_layer_get_selected_index(const SimpleMenuLayer* simple_menu)
+int simple_menu_layer_get_selected_index(const SimpleMenuLayer *simple_menu)
 {
     MenuIndex index = menu_layer_get_selected_index(simple_menu->menu_layer);
     return index.row;
 }
 
-void simple_menu_layer_set_selected_index(SimpleMenuLayer* simple_menu, int32_t index, bool animated)
+void simple_menu_layer_set_selected_index(SimpleMenuLayer *simple_menu, int32_t index, bool animated)
 {
     MenuIndex menu_index = {
         .section = 0,
@@ -104,7 +111,7 @@ void simple_menu_layer_set_selected_index(SimpleMenuLayer* simple_menu, int32_t 
     menu_layer_set_selected_index(simple_menu->menu_layer, menu_index, MenuRowAlignCenter, animated);
 }
 
-struct MenuLayer* simple_menu_layer_get_menu_layer(SimpleMenuLayer* simple_menu)
+struct MenuLayer* simple_menu_layer_get_menu_layer(SimpleMenuLayer *simple_menu)
 {
     return simple_menu->menu_layer;
 }

--- a/rwatch/ui/layer/simple_menu_layer.c
+++ b/rwatch/ui/layer/simple_menu_layer.c
@@ -1,0 +1,110 @@
+/* simple_menu_layer.h
+ * routines for the simple menu layer
+ * libRebbleOS
+ *
+ * Author: Barry Carter <barry.carter@gmail.com>
+ * Author: Hermann Noll <hermann.noll@hotmail.com>
+ */
+
+#include "simple_menu_layer.h"
+#include "menu_layer.h"
+
+static uint16_t prv_simple_menu_get_number_of_sections(struct MenuLayer* menu_layer, void* callback_context) {
+    SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
+    return simple_menu->num_sections;
+}
+
+static uint16_t prv_simple_menu_get_number_of_rows_in_section(struct MenuLayer* menu_layer, uint16_t section_index, void* callback_context) {
+    SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
+    return simple_menu->sections[section_index].num_items;
+}
+
+static int16_t prv_simple_menu_get_cell_height(struct MenuLayer* menu_layer, MenuIndex* cell_index, void* callback_context) {
+    return MENU_CELL_BASIC_CELL_HEIGHT;
+}
+
+static int16_t prv_simple_menu_get_header_height(struct MenuLayer* menu_layer, uint16_t section_index, void* callback_context) {
+    SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
+    return simple_menu->sections[section_index].title == NULL ? 0 : MENU_CELL_BASIC_HEADER_HEIGHT;
+}
+
+static void prv_simple_menu_draw_row(GContext* ctx, const Layer* cell_layer, MenuIndex* cell_index, void* callback_context) {
+    SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
+    const SimpleMenuItem* item = &simple_menu->sections[cell_index->section].items[cell_index->row];
+    menu_cell_basic_draw(ctx, cell_layer, item->title, item->subtitle, item->icon);
+}
+
+static void prv_simple_menu_draw_header(GContext* ctx, const Layer* cell_layer, uint16_t section_index, void* callback_context) {
+    SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
+    const SimpleMenuSection* section = &simple_menu->sections[section_index];
+    if (section->title != NULL) {
+        menu_cell_basic_header_draw(ctx, cell_layer, section->title);
+    }
+}
+
+static void prv_simple_menu_select(struct MenuLayer* menu_layer, MenuIndex* cell_index, void* callback_context) {
+    SimpleMenuLayer* simple_menu = (SimpleMenuLayer*)callback_context;
+    const SimpleMenuItem* item = &simple_menu->sections[cell_index->section].items[cell_index->row];
+    if (item->callback)
+        item->callback(cell_index->row, simple_menu->callback_context);
+}
+
+SimpleMenuLayer* simple_menu_layer_create(GRect frame, struct Window* window, const SimpleMenuSection* sections,
+                                          int32_t num_sections, void* callback_context)
+{
+    SimpleMenuLayer* simple_menu = app_calloc(1, sizeof(SimpleMenuLayer));
+    simple_menu->sections = sections;
+    simple_menu->num_sections = num_sections;
+    simple_menu->callback_context = callback_context;
+
+    struct MenuLayer* menu_layer = menu_layer_create(frame);
+    simple_menu->menu_layer = menu_layer;
+    menu_layer_set_click_config_onto_window(menu_layer, window);
+    menu_layer_set_callbacks(menu_layer, simple_menu, (MenuLayerCallbacks){
+        .get_num_sections = prv_simple_menu_get_number_of_sections,
+        .get_num_rows = prv_simple_menu_get_number_of_rows_in_section,
+        .get_cell_height = prv_simple_menu_get_cell_height,
+        .get_header_height = prv_simple_menu_get_header_height,
+        .draw_row = prv_simple_menu_draw_row,
+        .draw_header = prv_simple_menu_draw_header,
+        .select_click = prv_simple_menu_select,
+        .select_long_click = NULL,
+        .selection_changed = NULL,
+        .get_separator_height = NULL,
+        .selection_will_change = NULL,
+        .draw_background = NULL
+    });
+
+    return simple_menu;
+}
+
+void simple_menu_layer_destroy(SimpleMenuLayer* simple_menu)
+{
+    menu_layer_destroy(simple_menu->menu_layer);
+    app_free(simple_menu);
+}
+
+struct Layer* simple_menu_layer_get_layer(const SimpleMenuLayer* simple_menu)
+{
+    return menu_layer_get_layer(simple_menu->menu_layer);
+}
+
+int simple_menu_layer_get_selected_index(const SimpleMenuLayer* simple_menu)
+{
+    MenuIndex index = menu_layer_get_selected_index(simple_menu->menu_layer);
+    return index.row;
+}
+
+void simple_menu_layer_set_selected_index(SimpleMenuLayer* simple_menu, int32_t index, bool animated)
+{
+    MenuIndex menu_index = {
+        .section = 0,
+        .row = index
+    };
+    menu_layer_set_selected_index(simple_menu->menu_layer, menu_index, MenuRowAlignCenter, animated);
+}
+
+struct MenuLayer* simple_menu_layer_get_menu_layer(SimpleMenuLayer* simple_menu)
+{
+    return simple_menu->menu_layer;
+}

--- a/rwatch/ui/layer/simple_menu_layer.h
+++ b/rwatch/ui/layer/simple_menu_layer.h
@@ -17,31 +17,31 @@ typedef void(* SimpleMenuLayerSelectCallback)(int index, void *context);
 
 typedef struct SimpleMenuItem
 {
-    const char* title;
-    const char* subtitle;
-    GBitmap* icon;
+    const char *title;
+    const char *subtitle;
+    GBitmap *icon;
     SimpleMenuLayerSelectCallback callback;
 } SimpleMenuItem;
 
 typedef struct SimpleMenuSection
 {
-    const char* title;
-    const SimpleMenuItem* items;
+    const char *title;
+    const SimpleMenuItem *items;
     uint32_t num_items;
 } SimpleMenuSection;
 
 typedef struct SimpleMenuLayer
 {
-    struct MenuLayer* menu_layer;
-    const SimpleMenuSection* sections;
+    struct MenuLayer *menu_layer;
+    const SimpleMenuSection *sections;
     int32_t num_sections;
-    void* callback_context;
+    void *callback_context;
 } SimpleMenuLayer;
 
-SimpleMenuLayer* simple_menu_layer_create(GRect frame, struct Window* window, const SimpleMenuSection* sections,
-                                          int32_t num_sections, void* callback_context);
-void simple_menu_layer_destroy(SimpleMenuLayer* simple_menu);
-struct Layer* simple_menu_layer_get_layer(const SimpleMenuLayer* simple_menu);
-int simple_menu_layer_get_selected_index(const SimpleMenuLayer* simple_menu);
-void simple_menu_layer_set_selected_index(SimpleMenuLayer* simple_menu, int32_t index, bool animated);
-struct MenuLayer* simple_menu_layer_get_menu_layer(SimpleMenuLayer* simple_menu);
+SimpleMenuLayer* simple_menu_layer_create(GRect frame, struct Window *window, const SimpleMenuSection *sections,
+                                          int32_t num_sections, void *callback_context);
+void simple_menu_layer_destroy(SimpleMenuLayer *simple_menu);
+struct Layer* simple_menu_layer_get_layer(const SimpleMenuLayer *simple_menu);
+int simple_menu_layer_get_selected_index(const SimpleMenuLayer *simple_menu);
+void simple_menu_layer_set_selected_index(SimpleMenuLayer *simple_menu, int32_t index, bool animated);
+struct MenuLayer* simple_menu_layer_get_menu_layer(SimpleMenuLayer *simple_menu);

--- a/rwatch/ui/layer/simple_menu_layer.h
+++ b/rwatch/ui/layer/simple_menu_layer.h
@@ -1,0 +1,47 @@
+#pragma once
+/* simple_menu_layer.h
+ * routines for the simple menu layer
+ * libRebbleOS
+ *
+ * Author: Barry Carter <barry.carter@gmail.com>
+ * Author: Hermann Noll <hermann.noll@hotmail.com>
+ */
+
+#include "rect.h"
+
+struct Window;
+struct MenuLayer;
+struct Layer;
+
+typedef void(* SimpleMenuLayerSelectCallback)(int index, void *context);
+
+typedef struct SimpleMenuItem
+{
+    const char* title;
+    const char* subtitle;
+    GBitmap* icon;
+    SimpleMenuLayerSelectCallback callback;
+} SimpleMenuItem;
+
+typedef struct SimpleMenuSection
+{
+    const char* title;
+    const SimpleMenuItem* items;
+    uint32_t num_items;
+} SimpleMenuSection;
+
+typedef struct SimpleMenuLayer
+{
+    struct MenuLayer* menu_layer;
+    const SimpleMenuSection* sections;
+    int32_t num_sections;
+    void* callback_context;
+} SimpleMenuLayer;
+
+SimpleMenuLayer* simple_menu_layer_create(GRect frame, struct Window* window, const SimpleMenuSection* sections,
+                                          int32_t num_sections, void* callback_context);
+void simple_menu_layer_destroy(SimpleMenuLayer* simple_menu);
+struct Layer* simple_menu_layer_get_layer(const SimpleMenuLayer* simple_menu);
+int simple_menu_layer_get_selected_index(const SimpleMenuLayer* simple_menu);
+void simple_menu_layer_set_selected_index(SimpleMenuLayer* simple_menu, int32_t index, bool animated);
+struct MenuLayer* simple_menu_layer_get_menu_layer(SimpleMenuLayer* simple_menu);


### PR DESCRIPTION
Adds the simple_menu_layer API, but has a few requirements to work properly:

- the (cherry-picked) "halfass font cache" 4c717ff159777577964819d12657998c14d9c2a5
- the `property_animation` fixes (#61)
- the `menu_layer` fixes (#66)

No added test code until the unified approach announced by @ginge is here, but I just used the [official demo](https://github.com/pebble-examples/feature-simple-menu-layer).