### PR TITLE
Fix colors in MSYS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ STOP=\033[0m
 
 ifeq ($(VERBOSE),)
 QUIET = @
-SAY = @echo "${GREEN}"$(1)"${STOP}"
+SAY = @echo -e "${GREEN}"$(1)"${STOP}"
 else
 QUIET =
 SAY =


### PR DESCRIPTION
A really small change to fix colors in the MSYS shell. As `-e` is a standard argument, this will not change the behaviour on the Unix shells.