### PR TITLE
build our own resource packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Object files
 *.o
+*.pyc
 
 # Libraries
 *.lib

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "res"]
+	path = res
+	url = ../../pebble-dev/RebbleOS-resources

--- a/Apps/System/notification.c
+++ b/Apps/System/notification.c
@@ -11,6 +11,7 @@
 #include "librebble.h"
 #include "bitmap_layer.h"
 #include "action_bar_layer.h"
+#include "platform_res.h"
 
 const char *notif_name = "Notification";
 
@@ -22,11 +23,11 @@ void notif_init(void)
     char *title = "Test Alert";
     char *body = "Testing a basic notification on RebbleOS. Create it using notification_window_create, with an app_name, title, body, and optional icon.";
     
-    Notification *notification = notification_create(app, title, body, gbitmap_create_with_resource(77), GColorRed);
+    Notification *notification = notification_create(app, title, body, gbitmap_create_with_resource(RESOURCE_ID_ROUNDRECT_THING), GColorRed);
     
     window_stack_push_notification(notification);
     
-    Notification *notification_two = notification_create("Discord", "Join Us", "Join us on the Pebble Discord in the #firmware channel", gbitmap_create_with_resource(20), GColorFromRGB(85, 0, 170));
+    Notification *notification_two = notification_create("Discord", "Join Us", "Join us on the Pebble Discord in the #firmware channel", gbitmap_create_with_resource(RESOURCE_ID_ALARM_BELL_RINGING), GColorFromRGB(85, 0, 170));
     window_stack_push_notification(notification_two);
 }
 

--- a/Apps/System/systemapp.c
+++ b/Apps/System/systemapp.c
@@ -10,6 +10,7 @@
 #include "menu.h"
 #include "status_bar_layer.h"
 #include "platform_config.h"
+#include "platform_res.h"
 
 extern void flash_dump(void);
 
@@ -72,7 +73,7 @@ static MenuItems* watch_list_item_selected(const MenuItem *item) {
             node = node->next;
             continue;
         }
-        menu_items_add(items, MenuItem(node->name, "", 25, app_item_selected));
+        menu_items_add(items, MenuItem(node->name, "", RESOURCE_ID_CLOCK, app_item_selected));
 
         node = node->next;
     }
@@ -102,10 +103,10 @@ static void systemapp_window_load(Window *window)
     menu_set_click_config_onto_window(s_menu, window);
 
     MenuItems *items = menu_items_create(4);
-    menu_items_add(items, MenuItem("Watchfaces", "All your faces", 25, watch_list_item_selected));
-    menu_items_add(items, MenuItem("Settings", "Move Along", 24, test_item_selected));
-    menu_items_add(items, MenuItem("Tests", NULL, 25, run_test_item_selected));
-    menu_items_add(items, MenuItem("RebbleOS", "... v0.0.0.1", 24, NULL));
+    menu_items_add(items, MenuItem("Watchfaces", "All your faces", RESOURCE_ID_CLOCK, watch_list_item_selected));
+    menu_items_add(items, MenuItem("Settings", "Move Along", RESOURCE_ID_SPEECH_BUBBLE, test_item_selected));
+    menu_items_add(items, MenuItem("Tests", NULL, RESOURCE_ID_CLOCK, run_test_item_selected));
+    menu_items_add(items, MenuItem("RebbleOS", "... v0.0.0.1", RESOURCE_ID_SPEECH_BUBBLE, NULL));
     menu_set_items(s_menu, items);
 
 #ifdef PBL_RECT

--- a/Apps/System/test.c
+++ b/Apps/System/test.c
@@ -11,6 +11,7 @@
 #include "bitmap_layer.h"
 #include "action_bar_layer.h"
 #include "status_bar_layer.h"
+#include "platform_res.h"
 
 const char *test_name = "Test";
 
@@ -61,9 +62,9 @@ static void test_window_load(Window *window)
     action_bar = action_bar_layer_create();
     
     // Set the icons
-    GBitmap *icon1 = gbitmap_create_with_resource(21);
-    GBitmap *icon2 = gbitmap_create_with_resource(25);
-    GBitmap *icon3 = gbitmap_create_with_resource(22);
+    GBitmap *icon1 = gbitmap_create_with_resource(RESOURCE_ID_MUSIC_PLAY);
+    GBitmap *icon2 = gbitmap_create_with_resource(RESOURCE_ID_CLOCK);
+    GBitmap *icon3 = gbitmap_create_with_resource(RESOURCE_ID_MUSIC_PAUSE);
     action_bar_layer_set_icon(action_bar, BUTTON_ID_UP, icon1);
     action_bar_layer_set_icon(action_bar, BUTTON_ID_SELECT, icon2);
     action_bar_layer_set_icon(action_bar, BUTTON_ID_DOWN, icon3);

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ RebbleOS currently can be built for `snowy` (Pebble Time and Pebble Time
 Steel) and `tintin` (Pebble and Pebble Steel).  To build RebbleOS, follow
 these steps:
 
-* Obtain a checkout of the RebbleOS source code.
+* Obtain a checkout of the RebbleOS source code.  Ensure that you have also checked out the submodules required to build the resource tree: `git submodule update --init --recursive`
 * Create a `localconfig.mk` if your cross-compiler is in an unusual location.  For instance, if you have the SDK installed in `/home/me`, add the following line to your `localconfig.mk`: `PEBBLE_TOOLCHAIN_PATH=/home/me/Pebble/SDK/pebble-sdk-4.5-linux64/arm-cs-tools/bin`.  For more information on `localconfig.mk` variables, consult the `Makefile`.
 * Build the firmware: `make`
 * If you wish to run the firmware in `qemu`, copy the resources necessary into `Resources/`.  Take a look at [Utilities/mk_resources.sh](Utilities/mk_resources.sh) for more information on that.

--- a/Utilities/mkpack.py
+++ b/Utilities/mkpack.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python
+
+"""
+Builds a resource pack from a JSON description file.
+RebbleOS
+
+The general premise here is that there are two "and a half" output
+products from mkpack:
+
+  1) A pbpack file, which eventually goes inside of a pbz.  This gets
+     flashed in one of two ways: either through the Pebble PRF flash tools
+     (and, indirectly, from the Pebble apk or from libpebble2), or through
+     a "fake flash" tool that constructs a $PLATFORM_spi.bin for QEMU.
+
+  2) A C header file, which is included from RebbleOS.  Each resource
+     compiled by mkpack is given an enum entry, and the C header file
+     allows the resources to be references symbolically.
+
+  2.5) A dependency file, to be used by a build system.  Ideally, make
+       knows to ask mkpack to generate a dependency file; that way, a
+       pbpack is rebuilt every time either the input JSON changes, or any
+       of the resource pack inputs change.
+
+mkpack is smart enough to know to get resources in a handful of ways.  It
+can (aspirationally):
+
+  * Extract a raw resource from another resource pack (handy for
+    extracting fonts and such, before we have replacements of our own).
+  * Import a raw resource from disk (including a PNG, or a font file).
+  * Import an image from disk, converting and crushing to a palettized
+    PNG.
+  * Convert a graphic to system framebuffer format, for use as a splash
+    screen.
+"""
+
+__author__ = "Joshua Wise <joshua@joshuawise.com>"
+
+from stm32_crc import crc32
+import struct
+import json
+
+TAB_OFS = 0x0C
+RES_OFS = 0x200C
+
+def load_resource_from_pbpack(fname, resid):
+    """
+    Returns resource number |resid| from the pbpack file specified by
+    |fname|.
+    """
+    
+    with open(fname, 'rb') as f:
+        nrsrc = struct.unpack('I', f.read(4))[0]
+        
+        for i in range(nrsrc):
+            f.seek(TAB_OFS + i * 16)
+            (idx, ofs, sz, crc) = struct.unpack('iiiI', f.read(16))
+            
+            if idx == resid:
+                break
+        else:
+            raise IOError("res {} not found in pbpack \"{}\"".format(resid, fname))
+        
+        f.seek(RES_OFS + ofs)
+        return f.read(sz)
+
+def load_resource_from_disk(fname):
+    """
+    Simply loads a file.
+    """
+    
+    with open(fname, 'rb') as f:
+        return f.read()
+
+def save_pbpack(fname, rsrcs):
+    """
+    Outputs a handful of resources to a file.
+    
+    |rsrcs| is a list of resources, with the first mapping to resource index
+    "1".  Although the PebbleOS resource structure permits a sparse mapping
+    -- i.e., one in which one must read the whole resource table to find the
+    index that one desires -- the RebbleOS resource loader simply ignores
+    the ID number in each table entry, and indexes directly in to find what
+    it wants.  (And, further, every Pebble pbpack that I can find only has
+    them in order.)  So we, in keeping, will only generate things like that.
+    
+    """
+    
+    # First, turn the resource table into a list of entries, including
+    # index, offset, size, and CRC.
+    def mk_ent(data):
+        ent = {"idx": mk_ent.idx, "offset": mk_ent.offset, "size": len(data), "crc": crc32(data), "data": data}
+        mk_ent.offset += len(data)
+        mk_ent.idx += 1
+        return ent
+    mk_ent.offset = 0
+    mk_ent.idx = 1
+    rsrc_ents = [mk_ent(data) for data in rsrcs]
+    
+    with open(fname, 'wb+') as f:
+        f.write(struct.pack('I', len(rsrc_ents))) # Number of resources.
+        # We'll come back to the big CRC later.
+        
+        # Write out the table.
+        f.seek(TAB_OFS)
+        for ent in rsrc_ents:
+            f.write(struct.pack('iiiI', ent["idx"], ent["offset"], ent["size"], ent["crc"]))
+        
+        # Write out the resources themselves.
+        for ent in rsrc_ents:
+            f.seek(RES_OFS + ent["offset"])
+            f.write(ent["data"])
+        
+        # Now compute the CRC of the whole show.
+        f.seek(RES_OFS)
+        alldata = f.read()
+        
+        totlen = f.tell()
+        
+        f.seek(4)
+        f.write(struct.pack('I', crc32(alldata)))
+    
+    return totlen
+
+class Resource(object):
+    def __init__(self, coll, j):
+        self.coll = coll
+        self.name = j["name"]
+
+class ResourceRef(Resource):
+    def __init__(self, coll, j):
+        super(self.__class__, self).__init__(coll, j)
+        
+        self.resfile = self.coll.references[j["input"]["ref"]]
+        self.resid = j["input"]["id"]
+    
+    def deps(self):
+        return [self.resfile]
+    
+    def data(self):
+        return load_resource_from_pbpack(self.resfile, self.resid)
+    
+    def sourcedesc(self):
+        return "resource ID {} from pack {}".format(self.resid, self.resfile)
+
+class ResourceFile(Resource):
+    def __init__(self, coll, j):
+        super(self.__class__, self).__init__(coll, j)
+        
+        self.file = "{}/{}".format(self.coll.root, j["input"]["file"])
+    
+    def deps(self):
+        return [self.file]
+    
+    def data(self):
+        return load_resource_from_disk(self.file)
+    
+    def sourcedesc(self):
+        return self.file
+
+class ResourceCollection:
+    """
+    A collection of resources, as defined by a dictionary loaded from a JSON
+    file.
+    
+    A resource JSON file is defined as being a JSON dictionary, with the
+    following keys:
+    
+      * "references" is a dictionary, which maps friendly names to paths of
+         resource packs.
+         
+      * "resources" is a list.  Each element of the list is a dictionary,
+        describing one resource that will get included in the resource
+        bundle.  This dictionary, in turn, contains the following keys:
+        
+          * "name": A symbol name, for the resource header file.
+          
+          * "input": A dictionary, describing where to include this resource
+            from.  This dictionary should have a "type" key, which can be
+            "file" or "resource": if "file", then there should be a "file"
+            key, with a filename; if "resource", then there should be a
+            "ref" key, with a reference from "references" above, and an "id"
+            key, with a resource ID to load from that reference.
+    
+    """
+
+    def __init__(self, fname, root = "."):
+        """
+        Load in a resource collection from a file, but don't load the
+        resources associated with it.  (That happens later.)
+        """
+        
+        self.jfname = fname
+        self.root = root
+        
+        with open(fname, 'r') as f:
+            jdb = json.load(f)
+        
+        if "references" in jdb:
+            self.references = {k: "{}/{}".format(self.root, v) for k, v in jdb["references"].items()}
+        else:
+            self.references = {}
+        
+        self.resources = []
+        for res in jdb["resources"]:
+            if res["input"]["type"] == "file":
+                self.resources.append(ResourceFile(self, res))
+            elif res["input"]["type"] == "resource":
+                self.resources.append(ResourceRef(self, res))
+            else:
+                raise ValueError("unknown resource type {}".format(res["type"]))
+    
+    def deps(self):
+        """
+        List of all dependencies of this resource pack.
+        """
+        
+        deps = {}
+        for r in self.resources:
+            for d in r.deps():
+                deps[d] = True
+        return [d for d in deps]
+    
+    def rsrcs(self):
+        """
+        List of raw resource data in this resource pack.
+        """
+        
+        return [r.data() for r in self.resources]
+    
+    def write_pbpack(self, fname):
+        """
+        Write out a .pbpack file with all of the resources loaded.
+        """
+        
+        return save_pbpack(fname, self.rsrcs())
+    
+    def write_header(self, fname):
+        """
+        Write out a C header file that has symbolic names for resource
+        identifiers.
+        """
+        
+        with open(fname, 'w') as f:
+            f.write("/* THIS FILE IS AUTOMATICALLY GENERATED BY mkpack.py. */\n")
+            f.write("/* IF YOU MODIFY IT, YOU WILL BE VERY SAD. */\n")
+            f.write("/* IF YOU CHECK IT IN, I WILL BE VERY SAD. */\n")
+            f.write("\n")
+            f.write("#pragma once\n")
+            f.write("\n")
+            f.write("typedef enum resource_id {\n")
+            for (rid, r) in enumerate(self.resources):
+                f.write("    {} = {}, /* (from {}) */\n".format(r.name, rid + 1, r.sourcedesc()))
+            f.write("} resource_id;\n")
+    
+    def write_makedeps(self, fname, rsrcfile, hdrfile):
+        """
+        Write out a dependency file for 'make' to process.
+        
+        The generated header depends on the generated pbpack; the generated
+        pbpack depends on the source files.
+        """
+        
+        with open(fname, 'w') as f:
+            f.write("# automatically generated by mkpack.py\n\n")
+            f.write("{}: {} {} ".format(rsrcfile, self.jfname, __file__))
+            for d in self.deps():
+                f.write("{} ".format(d))
+            f.write("\n\n")
+            f.write("{}: {}\n\n".format(hdrfile, rsrcfile))
+            for d in self.deps():
+                f.write("{}:\n\n".format(d))
+            f.write("# That will conclude this evening's entertainment.\n")
+
+
+def main():
+    """
+    Command-line driver.
+    """
+    
+    import argparse
+    
+    parser = argparse.ArgumentParser(description = "Resource pack generator for RebbleOS.")
+    parser.add_argument("-r", "--root", nargs=1, default = ["."], help = "pathname to prepend to resource filenames.")
+    parser.add_argument("-M", "--make-dep", action="store_true", default = False, help = "produce a .d file to be included by 'make'")
+    parser.add_argument("-H", "--header", action = "store_true", default = False, help = "produce a .h file to be included in C source")
+    parser.add_argument("-P", "--pbpack", action = "store_true", default = False, help = "produce a .pbpack file")
+    parser.add_argument("json", help = "input JSON configuration file")
+    parser.add_argument("basename", help = "base output name ('.d', '.h', and '.pbpack' are appended automatically)")
+    args = parser.parse_args()
+    
+    rc = ResourceCollection(args.json, root = args.root[0])
+    
+    pbpack_name = "{}.pbpack".format(args.basename)
+    header_name = "{}.h".format(args.basename)
+    dep_name = "{}.d".format(args.basename)
+    if args.pbpack:
+        bytes = rc.write_pbpack(pbpack_name)
+        print("wrote {} ({} bytes)".format(pbpack_name, bytes))
+    if args.header:
+        rc.write_header(header_name)
+        print("wrote {}".format(header_name))
+    if args.make_dep:
+        rc.write_makedeps(dep_name, pbpack_name, header_name)
+        print("wrote {}".format(dep_name))
+
+if __name__ == '__main__':
+    main()

--- a/Utilities/stm32_crc.py
+++ b/Utilities/stm32_crc.py
@@ -1,0 +1,50 @@
+import array
+import sys
+
+CRC_POLY = 0x04C11DB7
+
+def process_word(data, crc=0xffffffff):
+    if (len(data) < 4):
+        d_array = array.array('B', data)
+        for x in range(0, 4 - len(data)):
+            d_array.insert(0,0)
+        d_array.reverse()
+        data = d_array.tostring()
+
+    d = array.array('I', data)[0]
+    crc = crc ^ d
+
+    for i in range(0, 32):
+        if (crc & 0x80000000) != 0:
+            crc = (crc << 1) ^ CRC_POLY
+        else:
+            crc = (crc << 1)
+
+    result = crc & 0xffffffff
+    return result
+
+def process_buffer(buf, c = 0xffffffff):
+    word_count = int(len(buf) / 4)
+    if (len(buf) % 4 != 0):
+        word_count += 1
+
+    crc = c
+    for i in range(0, word_count):
+        crc = process_word(buf[i * 4 : (i + 1) * 4], crc)
+    return crc
+
+def crc32(data):
+    return process_buffer(data)
+
+if __name__ == '__main__':
+    assert(0x89f3bab2 == process_buffer("123 567 901 34"))
+    assert(0xaff19057 == process_buffer("123456789"))
+    assert(0x519b130 == process_buffer("\xfe\xff\xfe\xff"))
+    assert(0x495e02ca == process_buffer("\xfe\xff\xfe\xff\x88"))
+
+    print("All tests passed!")
+
+    if len(sys.argv) >= 2:
+        b = open(sys.argv[1]).read()
+        crc = crc32(b)
+        print("%u or 0x%x" % (crc, crc))

--- a/docs/debian_build.md
+++ b/docs/debian_build.md
@@ -5,6 +5,7 @@ The following builds RebbleOS on Debian Stretch:
     apt install -y gcc-arm-none-eabi
     git clone https://github.com/ginge/FreeRTOS-Pebble.git
     cd FreeRTOS-Pebble
+    git submodule update --init --recursive
     make
 
 The Pebble SDK is a prerequisite for portions of RebbleOS. The

--- a/docs/mac_build.md
+++ b/docs/mac_build.md
@@ -4,6 +4,7 @@ The following builds RebbleOS on macOS:
 
     git clone https://github.com/ginge/FreeRTOS-Pebble.git
     cd FreeRTOS-Pebble
+    git submodule update --init --recursive
     make
 
 The Pebble SDK is a prerequisite for portions of RebbleOS. The

--- a/hw/platform/chalk/config.mk
+++ b/hw/platform/chalk/config.mk
@@ -11,5 +11,8 @@ LIBS_chalk = $(LIBS_snowy_family)
 
 QEMUFLAGS_chalk = -machine pebble-s4-bb -cpu cortex-m4
 QEMUSPITYPE_chalk = pflash
+QEMUPACKSIZE_chalk = 512000
+QEMUPACKOFS_chalk = 3670016
+QEMUSPINAME_chalk = chalk/3.0
 
 PLATFORMS += chalk

--- a/hw/platform/snowy/config.mk
+++ b/hw/platform/snowy/config.mk
@@ -11,5 +11,8 @@ LIBS_snowy = $(LIBS_snowy_family)
 
 QEMUFLAGS_snowy = -machine pebble-snowy-bb -cpu cortex-m4
 QEMUSPITYPE_snowy = pflash
+QEMUPACKSIZE_snowy = 512000
+QEMUPACKOFS_snowy = 3670016
+QEMUSPINAME_snowy = basalt/3.0
 
 PLATFORMS += snowy

--- a/rwatch/graphics/font_loader.c
+++ b/rwatch/graphics/font_loader.c
@@ -7,6 +7,7 @@
 
 #include "rebbleos.h"
 #include "librebble.h"
+#include "platform_res.h"
 
 // TODO This is still somewhat sketchy in that I'm not convinced some of these magic offsets
 // are right
@@ -86,7 +87,7 @@ void fonts_unload_custom_font(GFont font)
     app_free(font);
 }
 
-#define EQ_FONT(font) (strncmp(key, font, strlen(key)) == 0) return font ## _ID;
+#define EQ_FONT(font) (strncmp(key, "RESOURCE_ID_" #font, strlen(key)) == 0) return RESOURCE_ID_ ## font;
 
 /*
  * Load a font by a string key
@@ -101,40 +102,37 @@ uint16_t _fonts_get_resource_id_for_key(const char *key)
       
      */
     // so still seems like a bad choice, but backward compat.
-    if EQ_FONT(FONT_KEY_FONT_FALLBACK)
-    else if EQ_FONT(FONT_KEY_GOTHIC_09)
-    else if EQ_FONT(FONT_KEY_GOTHIC_14)
-    else if EQ_FONT(FONT_KEY_GOTHIC_14_BOLD)
-    else if EQ_FONT(FONT_KEY_GOTHIC_18)
-    else if EQ_FONT(FONT_KEY_GOTHIC_18_BOLD)
-    else if EQ_FONT(FONT_KEY_GOTHIC_24)
-    else if EQ_FONT(FONT_KEY_GOTHIC_24_BOLD)
-    else if EQ_FONT(FONT_KEY_GOTHIC_28)
-    else if EQ_FONT(FONT_KEY_GOTHIC_28_BOLD)
-
-    else if EQ_FONT(FONT_KEY_BITHAM_30_BLACK)
-    else if EQ_FONT(FONT_KEY_BITHAM_42_BOLD)
-    else if EQ_FONT(FONT_KEY_BITHAM_42_LIGHT)
-    else if EQ_FONT(FONT_KEY_BITHAM_42_MEDIUM_NUMBERS)
-    else if EQ_FONT(FONT_KEY_BITHAM_34_MEDIUM_NUMBERS)
-    else if EQ_FONT(FONT_KEY_BITHAM_34_LIGHT_SUBSET)
-    else if EQ_FONT(FONT_KEY_BITHAM_18_LIGHT_SUBSET)
-
-    else if EQ_FONT(FONT_KEY_ROBOTO_CONDENSED_21)
-    else if EQ_FONT(FONT_KEY_ROBOTO_BOLD_SUBSET_49)
-    else if EQ_FONT(FONT_KEY_DROID_SERIF_28_BOLD)
-
-    else if EQ_FONT(FONT_KEY_LECO_20_BOLD_NUMBERS)
-    else if EQ_FONT(FONT_KEY_LECO_26_BOLD_NUMBERS_AM_PM)
-    else if EQ_FONT(FONT_KEY_LECO_28_LIGHT_NUMBERS)
-    else if EQ_FONT(FONT_KEY_LECO_32_BOLD_NUMBERS)
-    else if EQ_FONT(FONT_KEY_LECO_36_BOLD_NUMBERS)
-    else if EQ_FONT(FONT_KEY_LECO_38_BOLD_NUMBERS)
-    else if EQ_FONT(FONT_KEY_LECO_42_NUMBERS)
-
-    else if EQ_FONT(FONT_KEY_AGENCY_FB_60_THIN_NUMBERS_AM_PM)
-    else if EQ_FONT(FONT_KEY_AGENCY_FB_60_NUMBERS_AM_PM)
-    else if EQ_FONT(FONT_KEY_AGENCY_FB_36_NUMBERS_AM_PM)
-        
-    return FONT_KEY_FONT_FALLBACK_ID;
+         if EQ_FONT(AGENCY_FB_60_THIN_NUMBERS_AM_PM)
+    else if EQ_FONT(AGENCY_FB_60_NUMBERS_AM_PM)
+    else if EQ_FONT(AGENCY_FB_36_NUMBERS_AM_PM)
+    else if EQ_FONT(GOTHIC_09)
+    else if EQ_FONT(GOTHIC_14)
+    else if EQ_FONT(GOTHIC_14_BOLD)
+    else if EQ_FONT(GOTHIC_18)
+    else if EQ_FONT(GOTHIC_18_BOLD)
+    else if EQ_FONT(GOTHIC_24)
+    else if EQ_FONT(GOTHIC_24_BOLD)
+    else if EQ_FONT(GOTHIC_28)
+    else if EQ_FONT(GOTHIC_28_BOLD)
+    else if EQ_FONT(GOTHIC_36)
+    else if EQ_FONT(BITHAM_18_LIGHT_SUBSET)
+    else if EQ_FONT(BITHAM_34_LIGHT_SUBSET)
+    else if EQ_FONT(BITHAM_30_BLACK)
+    else if EQ_FONT(BITHAM_42_BOLD)
+    else if EQ_FONT(BITHAM_42_LIGHT)
+    else if EQ_FONT(BITHAM_34_MEDIUM_NUMBERS)
+    else if EQ_FONT(BITHAM_42_MEDIUM_NUMBERS)
+    else if EQ_FONT(ROBOTO_CONDENSED_21)
+    else if EQ_FONT(ROBOTO_BOLD_SUBSET_49)
+    else if EQ_FONT(DROID_SERIF_28_BOLD)
+    else if EQ_FONT(LECO_20_BOLD_NUMBERS)
+    else if EQ_FONT(LECO_26_BOLD_NUMBERS_AM_PM)
+    else if EQ_FONT(LECO_32_BOLD_NUMBERS)
+    else if EQ_FONT(LECO_36_BOLD_NUMBERS)
+    else if EQ_FONT(LECO_38_BOLD_NUMBERS)
+    else if EQ_FONT(LECO_28_LIGHT_NUMBERS)
+    else if EQ_FONT(LECO_42_NUMBERS)
+    else if EQ_FONT(FONT_FALLBACK)
+                                                                                                                                
+    return RESOURCE_ID_FONT_FALLBACK;
 }


### PR DESCRIPTION
Ready to roll -- please test on non-Mac?

Still to do:
- [x] Wire `mkpack` to `Makefile`.
- [x] Create a basic resource pack.
- [x] Add include path for resources. 
- [x] Convert get_system_resource calls (including fonts_get_resource_id_for_key calls, gbitmap_create_with_resource calls, image_res_id in menus)
- [x] Figure out how to "flash" pbpacks.

The last item there requires some thought.  Currently qemu boots from Resources/$PLATFORM_spi.bin.  Presumably that's an input, and we don't want to pave over that to "flash" a pbpack into it.  We could copy that into build/$PLATFORM and `dd` into the middle of it, but once we start writing to the filesystem in RebbleOS, that would mean that we'd end up blowing away the filesystem that we're working with every time we create a new resource pack.  What say yinz?

Another thing that requires thought: if we submodule qemu-tintin-images, and extract the base `pbpack` from the SPI images from those, then where should they go?  If they go in `build/`, then that means that the `json` file has to point to `../build/` or whatever (especially tricky if we end up with putting the resources in their own submodule...), but if we put them in the same directory, then we have a build product not in `build/`.  My current theory is just to accept the grossness of pointing to `../build/` from the JSON, though I guess I could also add a `--refroot` option (by way of comparison with `--root` for direct resource includes).