### PR TITLE
Add windows build docu (thanks Tation)

### DIFF
--- a/docs/debian_build.md
+++ b/docs/debian_build.md
@@ -2,32 +2,33 @@
 
 The following builds RebbleOS on Debian Stretch:
 
+```sh
     apt install -y gcc-arm-none-eabi
     git clone https://github.com/ginge/FreeRTOS-Pebble.git
     cd FreeRTOS-Pebble
     make
+```
 
 The Pebble SDK is a prerequisite for portions of RebbleOS. The
 SDK is available at <https://developer.pebble.com/sdk/download/>.
 As an example, on Debian, one may create an installation
 directory for the SDK using the following.
 
+```sh
     mkdir ~/pebble-dev/
     cd ~/pebble-dev/
     wget https://s3.amazonaws.com/assets.getpebble.com/pebble-tool/pebble-sdk-4.5-linux64.tar.bz2
     tar -jxf pebble-sdk-4.5-linux64.tar.bz2
     echo 'export PATH=~/pebble-dev/pebble-sdk-4.5-linux64/bin:$PATH' >> ~/.bash_profile
     . ~/.bash_profile
-    sudo apt-get install python-pip python2.7-dev python-gevent
-    sudo pip install virtualenv
+    sudo apt-get update
+    sudo apt-get install python-pip python2.7-dev python-gevent libsdl1.2debian libfdt1 libpixman-1-0 git gcc-arm-none-eabi npm
+    pip install virtualenv
+    pip install --upgrade pip
     cd ~/pebble-dev/pebble-sdk-4.5-linux64
     virtualenv --no-site-packages .env
     source .env/bin/activate
     pip install -r requirements.txt
     deactivate
-
-The Pebble emulator requires the following libraries.
-
-    sudo apt-get install libsdl1.2debian libfdt1 libpixman-1-0
-
-
+    pebble ping --emulator aplite
+```

--- a/docs/windows_build.md
+++ b/docs/windows_build.md
@@ -8,12 +8,11 @@ So unfortunately there is no known way (yet), to fully work on Windows while wor
 - Download Linux ISO file (Ubuntu 16.04.3 LTS) from [their website](https://www.ubuntu.com/download/desktop)
 - Inside virtualbox install Ubuntu
 - You propably want to install the guest additions from VirtualBox
-- Once inside the booted Ubuntu, open a terminal and run these commands:
+- Once inside the booted Ubuntu, open a terminal for further install steps
 
 ### Install pebble SDK
 
 For installing the pebble sdk, please see the instructions in the [debian build documentation](https://github.com/ginge/FreeRTOS-Pebble/blob/master/docs/debian_build.md)
-To install the pebble core-sdk run `pebble ping --emulator aplite`. This should also test if qemu works with your setup.
 
 ### Setting up rebble development environment on Ubuntu
 
@@ -86,11 +85,11 @@ For building you can use this `tasks.json`:
         {
             "label": "Build all",
             "type": "shell",
-            "command": "C:/Users/Helco/Documents/Dev/2PC_ImportantProjects/pebbledev/msys/bin/make.exe",
+            "command": "C:\\msys\\bin\\make.exe",
             "args": [ ],
             "options": {
                 "env": {
-                    "PATH": "C:\\Users\\Helco\\Documents\\Dev\\2PC_ImportantProjects\\pebbledev\\msys\\bin"
+                    "PATH": "C:\\msys\\bin"
                 }
             },
             "group": {

--- a/docs/windows_build.md
+++ b/docs/windows_build.md
@@ -7,39 +7,23 @@ So unfortunately there is no known way (yet), to fully work on Windows while wor
 - Install [VirtualBox](http://www.virtualbox.org/)
 - Download Linux ISO file (Ubuntu 16.04.3 LTS) from [their website](https://www.ubuntu.com/download/desktop)
 - Inside virtualbox install Ubuntu
+- You propably want to install the guest additions from VirtualBox
 - Once inside the booted Ubuntu, open a terminal and run these commands:
 
 ### Install pebble SDK
 
-```
-mkdir ~/pebble-dev/
-cd ~/pebble-dev/
-wget https://s3.amazonaws.com/assets.getpebble.com/pebble-tool/pebble-sdk-4.5-linux64.tar.bz2
-tar -jxf pebble-sdk-4.5-linux64.tar.bz2
-echo 'export PATH=~/pebble-dev/pebble-sdk-4.5-linux64/bin:$PATH' >> ~/.bashrc
-. ~/.bashrc
-sudo apt-get update
-sudo apt-get install python-pip python2.7-dev python-gevent libsdl1.2debian libfdt1 libpixman-1-0 git gcc-arm-none-eabi npm
-pip install --upgrade pip
-pip install virtualenv
-cd ~/pebble-dev/pebble-sdk-4.5-linux64
-virtualenv --no-site-packages .env
-source .env/bin/activate
-pip install -r requirements.txt
-deactivate
-```
-
-To test if everything works correctly, run `pebble ping --emulator aplite`
+For installing the pebble sdk, please see the instructions in the [debian build documentation](https://github.com/ginge/FreeRTOS-Pebble/blob/master/docs/debian_build.md)
+To install the pebble core-sdk run `pebble ping --emulator aplite`. This should also test if qemu works with your setup.
 
 ### Setting up rebble development environment on Ubuntu
 
-```
+```sh
 cd ~/pebble-dev/
 git clone https://github.com/ginge/FreeRTOS-Pebble.git
 cd FreeRTOS-Pebble
 ./Utilities/mk_resources.sh ~/.pebble-sdk/SDKs/current/sdk-core/pebble/
-cd Resources 
-wget http://emarhavil.com/~joshua/snowy_fpga.bin http://emarhavil.com/~joshua/chalk_fpga.bin
+cd Resources
+wget # find the URLs of the fpga files in the `#firmware` channel in the Rebble Discord
 cd ..
 make
 make snowy_qemu
@@ -60,20 +44,20 @@ If you are a more experienced, you can follow these steps to gradually move some
 
 You can now compile the firmware by first cloning this repository and then running `make` (explicitly the one you downloaded) in the root folder, e.g.
 
-```
+```batch
 C:\msys\bin\make.exe snowy_qemu
 ```
 
 To prevent the copying of the compiled firmware, you can set up a shared folder in VirtualBox (in the menu tab "Devices"). However you can only have build files from either Windows or Linux present, which basically refrains you from using `make`. To start the emulator you have to run the command yourself (or put it in a bash script nearby):
 
-```
+```sh
 cat Resources/snowy_boot.bin build/snowy/tintin_fw.bin > build/snowy/fw.qemu_flash.bin
 qemu-pebble -rtc base=localtime -serial null -serial null -serial stdio -gdb tcp::63770,server -machine pebble-snowy-bb -cpu cortex-m4 -pflash build/snowy/fw.qemu_flash.bin -pflash Resources/snowy_spi.bin
 ```
 
 and to attach gdb to it:
 
-```
+```sh
 arm-none-eabi-gdb -ex "target remote localhost:63770" -ex "sym build/snowy/tintin_fw.elf"
 ```
 
@@ -87,7 +71,7 @@ For remote debugging to work you first have to enable the communication to your 
 
 Then you can start the emulator on the virtual machine by running `make snowy_qemu` and then in windows:
 
-```
+```batch
 C:\msys\bin\arm-none-eabi-gdb.exe -ex "target remote localhost:63770" -ex "sym build/snowy/tintin_fw.elf"
 ```
 
@@ -95,7 +79,7 @@ C:\msys\bin\arm-none-eabi-gdb.exe -ex "target remote localhost:63770" -ex "sym b
 
 For building you can use this `tasks.json`:
 
-```
+```json
 {
     "version": "2.0.0",
     "tasks": [

--- a/docs/windows_build.md
+++ b/docs/windows_build.md
@@ -1,0 +1,128 @@
+# Building on Windows
+
+So unfortunately there is no known way (yet), to fully work on Windows while working for Pebble. This document will guide you through the setup of a Ubuntu VM, the Pebble and Rebble development environment and finally look at some ways to move most of the development back to Windows.
+
+## Setting up a virtual machine 
+
+- Install [VirtualBox](http://www.virtualbox.org/)
+- Download Linux ISO file (Ubuntu 16.04.3 LTS) from [their website](https://www.ubuntu.com/download/desktop)
+- Inside virtualbox install Ubuntu
+- Once inside the booted Ubuntu, open a terminal and run these commands:
+
+### Install pebble SDK
+
+```
+mkdir ~/pebble-dev/
+cd ~/pebble-dev/
+wget https://s3.amazonaws.com/assets.getpebble.com/pebble-tool/pebble-sdk-4.5-linux64.tar.bz2
+tar -jxf pebble-sdk-4.5-linux64.tar.bz2
+echo 'export PATH=~/pebble-dev/pebble-sdk-4.5-linux64/bin:$PATH' >> ~/.bashrc
+. ~/.bashrc
+sudo apt-get update
+sudo apt-get install python-pip python2.7-dev python-gevent libsdl1.2debian libfdt1 libpixman-1-0 git gcc-arm-none-eabi npm
+pip install --upgrade pip
+pip install virtualenv
+cd ~/pebble-dev/pebble-sdk-4.5-linux64
+virtualenv --no-site-packages .env
+source .env/bin/activate
+pip install -r requirements.txt
+deactivate
+```
+
+To test if everything works correctly, run `pebble ping --emulator aplite`
+
+### Setting up rebble development environment on Ubuntu
+
+```
+cd ~/pebble-dev/
+git clone https://github.com/ginge/FreeRTOS-Pebble.git
+cd FreeRTOS-Pebble
+./Utilities/mk_resources.sh ~/.pebble-sdk/SDKs/current/sdk-core/pebble/
+cd Resources 
+wget http://emarhavil.com/~joshua/snowy_fpga.bin http://emarhavil.com/~joshua/chalk_fpga.bin
+cd ..
+make
+make snowy_qemu
+```
+
+That is all you need to develop for the Rebble firmware. You can use `make snowy_gdb` in a second terminal to attach GDB to your running emulator.
+
+## Setting up a development environment on Windows
+
+If you are a more experienced, you can follow these steps to gradually move some of the development process back to Windows. Please notice that this is not an alternative to the solution above, but rather an extension which should make life easier. As such setting it up can be rather complicated.
+
+### First steps
+
+- Download MSYS from [this website](https://sourceforge.net/projects/mingwbuilds/files/external-binary-packages/)
+- Extract it to some directory
+- Download the arm-none-eabi `Windows ZIP` package from [the ARM website](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads)
+- Extract it over MSYS (both archives have a bin folder with various *.exe files, these should be in the same folder after this step)
+
+You can now compile the firmware by first cloning this repository and then running `make` (explicitly the one you downloaded) in the root folder, e.g.
+
+```
+C:\msys\bin\make.exe snowy_qemu
+```
+
+To prevent the copying of the compiled firmware, you can set up a shared folder in VirtualBox (in the menu tab "Devices"). However you can only have build files from either Windows or Linux present, which basically refrains you from using `make`. To start the emulator you have to run the command yourself (or put it in a bash script nearby):
+
+```
+cat Resources/snowy_boot.bin build/snowy/tintin_fw.bin > build/snowy/fw.qemu_flash.bin
+qemu-pebble -rtc base=localtime -serial null -serial null -serial stdio -gdb tcp::63770,server -machine pebble-snowy-bb -cpu cortex-m4 -pflash build/snowy/fw.qemu_flash.bin -pflash Resources/snowy_spi.bin
+```
+
+and to attach gdb to it:
+
+```
+arm-none-eabi-gdb -ex "target remote localhost:63770" -ex "sym build/snowy/tintin_fw.elf"
+```
+
+### Remote Debugging
+
+For remote debugging to work you first have to enable the communication to your VM. The easiest way to do this (if you followed the steps above) is to open VirtualBox and select Your VM->Change->Networking->Advanced->Port Forwarding and add a new rule, which should like this:
+
+|  Name  | Protocol | Host-IP | Host-Port | Guest-IP | Guest-Port |
+|--------|----------|---------|:---------:|----------|:----------:|
+| Rule 1 | TCP      |         |   63770   |          |    63770   |
+
+Then you can start the emulator on the virtual machine by running `make snowy_qemu` and then in windows:
+
+```
+C:\msys\bin\arm-none-eabi-gdb.exe -ex "target remote localhost:63770" -ex "sym build/snowy/tintin_fw.elf"
+```
+
+### Integrating into VSCode
+
+For building you can use this `tasks.json`:
+
+```
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build all",
+            "type": "shell",
+            "command": "C:/Users/Helco/Documents/Dev/2PC_ImportantProjects/pebbledev/msys/bin/make.exe",
+            "args": [ ],
+            "options": {
+                "env": {
+                    "PATH": "C:\\Users\\Helco\\Documents\\Dev\\2PC_ImportantProjects\\pebbledev\\msys\\bin"
+                }
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$gcc",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared"
+            }
+        }
+    ]
+}
+```
+
+Unfortunately integrating remote debugging is still a problem, if you happen to solve it, please make a PR describing the solution!


### PR DESCRIPTION
Add docu about setting up an Ubuntu VirtualBox and setting up a Rebble development environment (written by Tation).

Additionally some tips on how to move some of the development process back to Windows to make life (and CPU stress) easier.