### PR TITLE
app manager: fix THUMB call into main()

### DIFF
--- a/rcore/appmanager.c
+++ b/rcore/appmanager.c
@@ -669,7 +669,7 @@ static void _appmanager_app_thread(void *parms)
             KERN_LOG("app", APP_LOG_LEVEL_DEBUG, "Reloc:%d", header.reloc_entries_count);
             KERN_LOG("app", APP_LOG_LEVEL_DEBUG, "VSize 0x%x", header.virtual_size);
              
-            _running_app->main = (AppMainHandler)&app_stack_heap.byte_buf[header.offset];
+            _running_app->main = (AppMainHandler)((uint32_t)(&app_stack_heap.byte_buf[header.offset]) | 1);
         }
         else
         {


### PR DESCRIPTION
Does anybody know why we have to do this?  Why aren't they passing us function pointers that have the THUMB bit set already?