### PR TITLE
Fix ClickHandler context

### DIFF
--- a/rcore/buttons.c
+++ b/rcore/buttons.c
@@ -373,6 +373,8 @@ void button_raw_click_subscribe(ButtonId button_id, ClickHandler down_handler, C
     ButtonHolder *holder = _button_holders[button_id]; // get the button
     holder->click_config.raw.up_handler = up_handler;
     holder->click_config.raw.down_handler = down_handler;
+    if (context != NULL)
+        holder->click_config.context = context;
 }
 
 void button_unsubscribe_all(void)

--- a/rwatch/input/click_config.h
+++ b/rwatch/input/click_config.h
@@ -54,7 +54,6 @@ typedef struct ClickConfig
     {
         ClickHandler up_handler;
         ClickHandler down_handler;
-        void *context;
     } raw;
 } ClickConfig;
 


### PR DESCRIPTION
According to the documentation: 

- the `ClickHandler` context should default to the `ClickProvider` context (which in turn defaults to the window)
- the context given to `window_raw_click_subscribe` should override the general context