### PR TITLE
Fix some window/layer bugs

### DIFF
--- a/rwatch/ui/layer/layer.c
+++ b/rwatch/ui/layer/layer.c
@@ -86,6 +86,7 @@ void layer_add_child(Layer *parent_layer, Layer *child_layer)
     {
         parent_layer->child = child_layer;
         child_layer->parent = parent_layer;
+        child_layer->window = parent_layer->window;
         return;
     }
     
@@ -104,6 +105,7 @@ void layer_add_child(Layer *parent_layer, Layer *child_layer)
     
     child->sibling = child_layer;
     child_layer->parent = parent_layer;
+    child_layer->window = parent_layer->window;
 
     layer_mark_dirty(parent_layer);
 }
@@ -231,6 +233,7 @@ static void _layer_insert_node(Layer *layer_to_insert, Layer *sibling_layer, boo
         layer_to_insert->sibling = sibling_layer->sibling;
         sibling_layer->sibling = layer_to_insert;
     }
+    layer_to_insert->window = sibling_layer->window;
 }
 
 static void _layer_remove_node(Layer *to_be_removed)

--- a/rwatch/ui/window.h
+++ b/rwatch/ui/window.h
@@ -66,7 +66,9 @@ typedef struct Window
 
 // Window management
 Window *window_create();
-void window_destroy(Window *window) ;
+void window_ctor(Window *window);
+void window_destroy(Window *window);
+void window_dtor(Window *window);
 void window_set_click_config_provider(Window *window, ClickConfigProvider click_config_provider);
 void window_set_click_config_provider_with_context(Window *window, ClickConfigProvider click_config_provider, void *context);
 ClickConfigProvider window_get_click_config_provider(const Window *window);


### PR DESCRIPTION
- switching windows does not trigger redraw
- switching windows does not remove old click configs
- `window_stack_remove` does not configure the new window
- the `window` field on `layer` is not set
- added ctor/dtor function to allow for inheritance (used in `action_menu` soon™)