### PR TITLE
small fixes in menus

### DIFF
--- a/Apps/System/systemapp.c
+++ b/Apps/System/systemapp.c
@@ -73,7 +73,7 @@ static MenuItems* watch_list_item_selected(const MenuItem *item) {
             node = node->next;
             continue;
         }
-        menu_items_add(items, MenuItem(node->name, "", RESOURCE_ID_CLOCK, app_item_selected));
+        menu_items_add(items, MenuItem(node->name, NULL, RESOURCE_ID_CLOCK, app_item_selected));
 
         node = node->next;
     }

--- a/rcore/appmanager_app_runloop.c
+++ b/rcore/appmanager_app_runloop.c
@@ -71,6 +71,7 @@ void app_event_loop(void)
         KERN_LOG("app", APP_LOG_LEVEL_ERROR, "Naughty! You tried to run an app runloop!. You are not an app");
         return;
     }
+    fonts_resetcache();
     
     KERN_LOG("app", APP_LOG_LEVEL_INFO, "App entered mainloop");
     


### PR DESCRIPTION
small fixes:
- In Watchfaces Menu: show titles vertically aligned (as they don`t have subtitles). 
- Reset fonts cache when entering/exiting from systemapps/watchfaces,... (_cached_fonts is static, but GFont elements inside are freed, so cache is invalid).

[gif before fixes](http://www.giphy.com/gifs/xUOwG7LLzkd66a2KqI)
[gif after fixes](http://www.giphy.com/gifs/xUOwGk467HNXfdyLK0)