### PR TITLE
Fix action_menu (somewhat)

### DIFF
--- a/Apps/System/testapp.c
+++ b/Apps/System/testapp.c
@@ -81,6 +81,13 @@ app_test _tests[] = {
         .test_init = &menu_multi_column_test_init,
         .test_execute = &menu_multi_column_test_exec,
         .test_deinit = &menu_multi_column_test_deinit
+    },
+    {
+        .test_name = "Action Test",
+        .test_desc = "Action Menu Test",
+        .test_init = &action_menu_test_init,
+        .test_execute = &action_menu_test_exec,
+        .test_deinit = &action_menu_test_deinit
     }
 };
 

--- a/Apps/System/tests/action_menu_test.c
+++ b/Apps/System/tests/action_menu_test.c
@@ -1,0 +1,81 @@
+/* action_menu_test.c
+ * RebbleOS
+ * 
+ * Author: Hermann Noll <hermann.noll@hotmail.com>
+ */
+
+#include "librebble.h"
+#include "action_menu.h"
+#include "test_defs.h"
+
+static TextLayer *s_label;
+static ActionMenu *s_action_menu;
+static ActionMenuLevel *s_root_level, *s_sub_level;
+
+static void _action_performed(ActionMenu *action_menu, const ActionMenuItem *action, void *context)
+{
+    test_complete(true);
+}
+
+static void _select_click(ClickRecognizerRef rec, void *context)
+{
+    ActionMenuConfig config = (ActionMenuConfig){
+        .root_level = s_root_level,
+        .colors = {
+            .background = GColorChromeYellow,
+            .foreground = GColorBlue},
+        .align = ActionMenuAlignTop};
+
+    s_action_menu = action_menu_open(&config);
+}
+
+static void _back_click(ClickRecognizerRef rec, void *context)
+{
+    test_complete(false);
+}
+
+static void _click_config_provider(void *context)
+{
+    window_single_click_subscribe(BUTTON_ID_SELECT, _select_click);
+    window_single_click_subscribe(BUTTON_ID_BACK, _back_click);
+}
+
+bool action_menu_test_init(Window *window)
+{
+    Layer *window_layer = window_get_root_layer(window);
+    GRect frame = layer_get_frame(window_layer);
+    window_set_background_color(window, GColorWhite);
+    window_set_click_config_provider(window, _click_config_provider);
+
+    s_label = text_layer_create(GRect(frame.origin.x, frame.origin.y + frame.size.h/2 - 24, frame.size.w, frame.size.h));
+    text_layer_set_text(s_label, "Press SELECT to open the ActionMenu");
+    text_layer_set_font(s_label, fonts_get_system_font(FONT_KEY_GOTHIC_14_BOLD));
+    text_layer_set_text_color(s_label, GColorBlack);
+    layer_add_child(window_layer, text_layer_get_layer(s_label));
+
+    // Create the root level
+    s_root_level = action_menu_level_create(4);
+    action_menu_level_add_action(s_root_level, "First", _action_performed, NULL);
+    action_menu_level_add_action(s_root_level, "Second", _action_performed, NULL);
+    action_menu_level_add_action(s_root_level, "Third", _action_performed, NULL);
+
+    // Create and set up the secondary level, adding it as a child to the root one
+    s_sub_level = action_menu_level_create(3);
+    action_menu_level_add_child(s_root_level, s_sub_level, "Sub level");
+    action_menu_level_add_action(s_sub_level, "Sub First", _action_performed, NULL);
+    action_menu_level_add_action(s_sub_level, "Sub Second", _action_performed, NULL);
+    action_menu_level_add_action(s_sub_level, "Sub Third", _action_performed, NULL);
+
+    return true;
+}
+
+bool action_menu_test_exec(void)
+{
+    return true;
+}
+
+bool action_menu_test_deinit(void)
+{
+    layer_remove_from_parent(text_layer_get_layer(s_label));
+    return true;
+}

--- a/Apps/System/tests/config.mk
+++ b/Apps/System/tests/config.mk
@@ -6,3 +6,4 @@ SRCS_all += Apps/System/tests/color_test.c
 SRCS_all += Apps/System/tests/overlay_test.c
 SRCS_all += Apps/System/tests/menu_simple_test.c
 SRCS_all += Apps/System/tests/menu_multi_column_test.c
+SRCS_all += Apps/System/tests/action_menu_test.c

--- a/Apps/System/tests/test_defs.h
+++ b/Apps/System/tests/test_defs.h
@@ -145,3 +145,7 @@ bool menu_simple_test_deinit(void);
 bool menu_multi_column_test_init(Window* window);
 bool menu_multi_column_test_exec(void);
 bool menu_multi_column_test_deinit(void);
+
+bool action_menu_test_init(Window *window);
+bool action_menu_test_exec(void);
+bool action_menu_test_deinit(void);

--- a/rwatch/ui/action_menu.c
+++ b/rwatch/ui/action_menu.c
@@ -5,125 +5,163 @@
  * RebbleOS
  * 
  * Author: Carson Katri <me@carsonkatri.com>.
+ * Author: Hermann Noll <hermann.noll@hotmail.com>
  */
 
 #include "rebbleos.h"
 #include "action_menu.h"
+#include "menu_layer.h"
+#include "pebble_defines.h"
 
-/* STRUCT DEFS */
-struct ActionMenuLevel
-{
-    ActionMenuLevelDisplayMode *display_mode;
-    ActionMenuItem *items;
-    int count;
-    uint16_t *capacity;
-    int index;
-};
+#define ACTION_MENU_SIDEBAR_SIZE        PBL_IF_RECT_ELSE(14, 11)
+#define ACTION_MENU_CRUMB_PADDING 8
+#define ACTION_MENU_CRUMB_SIZE 5
+
+#define ACTION_MENU_CELL_HEIGHT         PBL_IF_RECT_ELSE(40, 32)
+#define ACTION_MENU_FOCUSED_CELL_HEIGHT PBL_IF_RECT_ELSE(40, 70)
+#define ACTION_MENU_CELL_FONT           FONT_KEY_GOTHIC_18_BOLD
+#define ACTION_MENU_FOCUSED_CELL_FONT   PBL_IF_RECT_ELSE(FONT_KEY_GOTHIC_18_BOLD, FONT_KEY_GOTHIC_24_BOLD)
+
+#define ACTION_MENU_LEVEL_INDICATOR "\xC2\xBB" // RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
 
 struct ActionMenuItem
 {
-    ActionMenuLevel *level;
-    char *label;
+    const char *label;
     void *action_data;
     ActionMenuPerformActionCb cb;
 };
 
-struct ActionMenu
+struct ActionMenuLevel
 {
-    ActionMenuConfig *config;
-    int *level_index;
-    Window *result_window;
-    MenuLayer *menu_layer;
+    ActionMenuLevel* parent; // looking at the API only one parent per level is allowed
+    ActionMenuLevelDisplayMode display_mode;
+    uint16_t count;
+    uint16_t capacity;
+    ActionMenuItem items[];
 };
 
-/* END */
+struct ActionMenu
+{
+    Window window;
+    MenuLayer *menu_layer;
+    ActionMenuConfig config;
+    const ActionMenuLevel* cur_level;
+    uint16_t level_index;
+    bool is_frozen;
+    Window *result_window;
+};
 
-char * action_menu_item_get_label(const ActionMenuItem * item)
+const char *action_menu_item_get_label(const ActionMenuItem *item)
 {
     return item->label;
 }
 
-void * action_menu_item_get_action_data(const ActionMenuItem * item)
+void *action_menu_item_get_action_data(const ActionMenuItem *item)
 {
     return item->action_data;
 }
 
-ActionMenuLevel * action_menu_level_create(uint16_t max_items)
+ActionMenuLevel *action_menu_level_create(uint16_t max_items)
 {
     ActionMenuLevel *level = (ActionMenuLevel *)app_calloc(1, sizeof(ActionMenuLevel) + (sizeof(ActionMenuItem) * max_items));
     level->capacity = max_items;
     level->count = 0;
-    level->index = 0;
+    level->parent = NULL;
     
     return level;
 }
 
-void action_menu_level_set_display_mode(ActionMenuLevel * level, ActionMenuLevelDisplayMode display_mode)
+void action_menu_level_set_display_mode(ActionMenuLevel *level, ActionMenuLevelDisplayMode display_mode)
 {
-    level->display_mode = (ActionMenuLevelDisplayMode *) display_mode;
+    level->display_mode = display_mode;
 }
 
-ActionMenuItem * action_menu_level_add_action(ActionMenuLevel * level, const char *label, ActionMenuPerformActionCb cb, void * action_data)
+ActionMenuItem *action_menu_level_add_action(ActionMenuLevel *level, const char *label, ActionMenuPerformActionCb cb, void *action_data)
 {
-    ActionMenuItem *items = level->items;
+    if (level->count >= level->capacity) {
+        return NULL;
+    }
     
-    ActionMenuItem *new_item = (ActionMenuItem *)app_calloc(1, sizeof(ActionMenuItem));
+    ActionMenuItem *new_item = &level->items[level->count++];
     new_item->label = label;
-    new_item->level = level;
     new_item->cb = cb;
     new_item->action_data = action_data;
-    
-    if (level->capacity == level->count)
-        return NULL;
-    
-    items[level->count++] = *new_item;
     return new_item;
 }
 
-static void child_level_action_performed_callback(ActionMenu *action_menu, const ActionMenuItem *action, void *context)
+static void _child_level_action_performed_callback(ActionMenu *action_menu, const ActionMenuItem *action, void *context)
 {
-    // Switch levels
-    action_menu->level_index += 1;
+    action_menu->level_index++;
+    action_menu->cur_level = (ActionMenuLevel*)action->action_data;
+
+    MenuIndex zero_index = { .row = 0, .section = 0 };
+    menu_layer_set_selected_index(action_menu->menu_layer, zero_index, MenuRowAlignCenter, false);
+    menu_layer_reload_data(action_menu->menu_layer);
+    // TODO: start animation
 }
 
-ActionMenuItem * action_menu_level_add_child(ActionMenuLevel * level, ActionMenuLevel * child, const char * label)
+ActionMenuItem *action_menu_level_add_child(ActionMenuLevel *level, ActionMenuLevel *child, const char *label)
 {
-    return action_menu_level_add_action(level, label, child_level_action_performed_callback, child);
+    child->parent = level;
+    return action_menu_level_add_action(level, label, _child_level_action_performed_callback, child);
 }
 
-void action_menu_hierarchy_destroy(const ActionMenuLevel * root, ActionMenuEachItemCb each_cb, void * context)
+void action_menu_hierarchy_destroy(ActionMenuLevel *root, ActionMenuEachItemCb each_cb, void *context)
 {
-    app_free(root->display_mode);
-    app_free(root->items);
-    
-    app_free(root);
+    uint16_t i;
+    ActionMenuLevel* cur_node = root;
+    while (cur_node != NULL) {
+        // Traverse all sub-levels
+        for (i = 0; i < cur_node->count; i++) {
+            if (cur_node->items[i].cb == _child_level_action_performed_callback) {
+                cur_node->items[i].cb = NULL;
+                cur_node = (ActionMenuLevel *)cur_node->items[i].action_data;
+                break;
+            }
+        }
+        if (i < cur_node->count)
+            continue;
+
+        // Call each_cb on every child
+        if (each_cb != NULL) {
+            for (i = 0; i < cur_node->count; i++) {
+                each_cb(&cur_node->items[i], context);
+            }
+        }
+
+        // Back to parent
+        ActionMenuLevel* tmp = cur_node->parent;
+        app_free(cur_node);
+        cur_node = tmp;
+    }
 }
 
-void * action_menu_get_context(ActionMenu * action_menu)
+void *action_menu_get_context(ActionMenu *action_menu)
 {
-    return action_menu->config->context;
+    return action_menu->config.context;
 }
 
-ActionMenuLevel * action_menu_get_root_level(ActionMenu * action_menu)
+const ActionMenuLevel *action_menu_get_root_level(ActionMenu *action_menu)
 {
-    return action_menu->config->root_level;
+    return action_menu->config.root_level;
 }
 
-static void side_bar_update_proc(Layer *layer, GContext *nGContext)
+static void _side_bar_update_proc(Layer *layer, GContext *nGContext)
 {
-    ActionMenu *action_menu = (ActionMenu *) layer->container;
-    ActionMenuConfig *config = action_menu->config;
+    Window* window = layer_get_window(layer);
+    ActionMenu *action_menu = (ActionMenu *)window;
+    ActionMenuConfig *config = &action_menu->config;
+
+    //TODO: Reprocess this el hermano!
     
 #ifdef PBL_RECT
-    // Draw the sidebar:
     graphics_context_set_fill_color(nGContext, config->colors.background);
     graphics_fill_rect(nGContext, GRect(0, 0, layer->frame.size.w, layer->frame.size.h), 0, GCornerNone);
     
-    // Draw the level:
-    int index = action_menu->level_index;
-    SYS_LOG("notification_window", APP_LOG_LEVEL_DEBUG, "INDEX: %d", index);
-    graphics_context_set_fill_color(nGContext, GColorWhite);
-    n_graphics_fill_circle(nGContext, GPoint(layer->frame.size.w / 2, (10 * (index + 1)) + (5 * index)), 4);
+    graphics_context_set_fill_color(nGContext, config->colors.foreground);
+    for (int i = 0; i <= action_menu->level_index; i++) {
+        n_graphics_fill_circle(nGContext, GPoint(layer->frame.size.w / 2, 8 * (i + 1) + 2), 2);
+    }
 #else
     // On round, just draw a circle around the menu
     graphics_context_set_stroke_color(nGContext, config->colors.background);
@@ -132,131 +170,181 @@ static void side_bar_update_proc(Layer *layer, GContext *nGContext)
 #endif
 }
 
-static uint16_t get_num_rows_callback(MenuLayer *menu_layer,
-                                      uint16_t section_index, void *context) {
-    ActionMenu *action_menu = (ActionMenu *) context;
-    const uint16_t num_rows = 3;
-    return num_rows;
+static uint16_t _get_num_rows_callback(MenuLayer *menu_layer, uint16_t section_index, void *context)
+{
+    ActionMenu *action_menu = (ActionMenu *)context;
+    return action_menu->cur_level->count;
 }
 
-static void draw_row_callback(GContext *ctx, const Layer *cell_layer,
-                              MenuIndex *cell_index, void *context) {
+static void _draw_row_callback(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_index, void *context)
+{
     GRect frame = cell_layer->frame;
     ActionMenu *action_menu = (ActionMenu *) context;
     
-    // Draw this row's index
-    ctx->text_color = GColorWhite;
+    bool is_highlighted = menu_layer_is_index_selected(action_menu->menu_layer, cell_index);
+    ctx->text_color = is_highlighted ? GColorWhite : GColorDarkGray;
+    const char *item_label = action_menu->cur_level->items[cell_index->row].label;
     
-    const char *item_text = &action_menu->config->root_level->items[cell_index->row].label;
-    
-#ifdef PBL_RECT
-    GTextAlignment align = GTextAlignmentLeft;
-    GFont item_font = fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD);
-    GRect item_rect = GRect(30, frame.size.h / 2 - 16, frame.size.w - 35, 24);
-    graphics_draw_text(ctx, item_text, item_font, item_rect, GTextOverflowModeTrailingEllipsis, align, 0);
-#else
-    GTextAlignment align = GTextAlignmentCenter;
-    GFont item_font = fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD);
-    GRect item_rect = GRect(20, frame.size.h / 2 - 16, frame.size.w - 25, 24);
-    graphics_draw_text(ctx, item_text, item_font, item_rect, GTextOverflowModeTrailingEllipsis, align, 0);
-#endif
+    GTextAlignment align = MENU_DEFAULT_TEXT_ALIGNMENT;
+    GFont item_font = fonts_get_system_font(is_highlighted ? ACTION_MENU_FOCUSED_CELL_FONT : ACTION_MENU_CELL_FONT);
+    GRect item_rect = PBL_IF_RECT_ELSE(
+        GRect(ACTION_MENU_SIDEBAR_SIZE + 6, frame.size.h / 2 - 16,
+              frame.size.w - 2 * ACTION_MENU_SIDEBAR_SIZE, 24), /* rect */
+        GRect(0, frame.size.h / 2 - 16, frame.size.w, 24)  /* round */
+    );
+    graphics_draw_text(ctx, item_label, item_font, item_rect, GTextOverflowModeTrailingEllipsis, align, NULL);
+
+    // draw level indicator
+    if (is_highlighted && action_menu->cur_level->items[cell_index->row].cb == _child_level_action_performed_callback) {
+        GFont indicator_font = fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD);
+        GRect indicator_rect = PBL_IF_RECT_ELSE(
+            GRect(frame.size.w - ACTION_MENU_SIDEBAR_SIZE, frame.size.h/2 - 24,
+                  ACTION_MENU_SIDEBAR_SIZE, 16), /* rect */
+            GRect(0, 28, frame.size.w, 16)       /* round TODO: Fix text size calculation and use text_height + padding */
+        );
+        graphics_draw_text(ctx, ACTION_MENU_LEVEL_INDICATOR, indicator_font, indicator_rect, 
+                               GTextOverflowModeTrailingEllipsis, align, NULL);
+    }
 }
 
-static int16_t get_cell_height_callback(struct MenuLayer *menu_layer,
-                                        MenuIndex *cell_index, void *context) {
-#ifdef PBL_RECT
-    const int16_t cell_height = 44;
-#else
-    const int16_t cell_height = 180;
-#endif
-    return cell_height;
-}
-
-static void item_selected(struct MenuLayer *menu_layer,
-                            MenuIndex *cell_index, void *context) {
-    // Do something in response to the button press
-}
-
-static void action_menu_window_load(Window *window)
+static int16_t _get_cell_height_callback(struct MenuLayer *menu_layer, MenuIndex *cell_index, void *context)
 {
-    ActionMenu *action_menu = (ActionMenu *) window->user_data;
-    ActionMenuConfig *config = action_menu->config;
-    
-    // Make a menu
-    GRect frame = layer_get_unobstructed_bounds(window_get_root_layer(window));
-    action_menu->menu_layer = menu_layer_create(frame);
-    menu_layer_set_callbacks(action_menu->menu_layer, NULL, (MenuLayerCallbacks) {
-        .get_num_rows = get_num_rows_callback,
-        .draw_row = draw_row_callback,
-        .get_cell_height = get_cell_height_callback,
-        .select_click = item_selected
-    });
-    layer_add_child(window_get_root_layer(window), menu_layer_get_layer(action_menu->menu_layer));
-    
-    action_menu->menu_layer->bg_color = GColorBlack;
-    action_menu->menu_layer->bg_hi_color = GColorBlack;
-    action_menu->menu_layer->fg_hi_color = GColorWhite;
-    action_menu->menu_layer->fg_color = GColorWhite;
-    
-    //menu_layer_set_click_config_provider(action_menu->menu_layer, (ClickConfigProvider) menu_click_config_provider);
-    menu_layer_set_click_config_onto_window(action_menu->menu_layer, window);
-    
-    action_menu->menu_layer->context = action_menu;
-#ifdef PBL_RECT
-    Layer *side_bar_layer = layer_create(GRect(0, 0, 20, DISPLAY_ROWS));
-#else
-    Layer *side_bar_layer = layer_create(GRect(0, 0, DISPLAY_COLS, DISPLAY_ROWS));
-#endif
-    side_bar_layer->container = action_menu;
-    layer_set_update_proc(side_bar_layer, side_bar_update_proc);
-    
-    layer_add_child(window_get_root_layer(window), side_bar_layer);
-    
-    layer_mark_dirty(menu_layer_get_layer(action_menu->menu_layer));
+    MenuIndex focused_index = menu_layer_get_selected_index(menu_layer);
+    return cell_index->row == focused_index.row
+        ? ACTION_MENU_FOCUSED_CELL_HEIGHT
+        : ACTION_MENU_CELL_HEIGHT;
 }
 
-static void action_menu_window_unload(Window *window)
+static void _action_menu_select_prev(ClickRecognizerRef recognizer, void *context)
+{
+    ActionMenu *action_menu = (ActionMenu*)context;
+    if (!action_menu->is_frozen)
+        menu_layer_set_selected_next(action_menu->menu_layer, true, MenuRowAlignCenter, true);
+}
+
+static void _action_menu_select_next(ClickRecognizerRef recognizer, void *context)
+{
+    ActionMenu *action_menu = (ActionMenu*)context;
+    if (!action_menu->is_frozen)
+        menu_layer_set_selected_next(action_menu->menu_layer, false, MenuRowAlignCenter, true);
+}
+
+static void _action_menu_activate_item(ClickRecognizerRef recognizer, void *context)
+{
+    ActionMenu *action_menu = (ActionMenu*)context;
+    if (!action_menu->is_frozen) {
+        MenuIndex index = menu_layer_get_selected_index(action_menu->menu_layer);
+        const ActionMenuItem* item = &action_menu->cur_level->items[index.row];
+
+        if (item->cb) {
+            item->cb(action_menu, item, item->action_data);
+
+            if (item->cb != _child_level_action_performed_callback)
+                action_menu_close(action_menu, true);
+        }
+    }
+}
+
+static void _action_menu_prev_level(ClickRecognizerRef recognizer, void* context)
+{
+    ActionMenu *action_menu = (ActionMenu*)context;
+    if (!action_menu->is_frozen) {
+        if (action_menu->level_index > 0) {
+            action_menu->level_index--;
+            action_menu->cur_level = action_menu->cur_level->parent;
+
+            MenuIndex zero_index = { .row = 0, .section = 0 };
+            menu_layer_set_selected_index(action_menu->menu_layer, zero_index, MenuRowAlignCenter, false);
+            menu_layer_reload_data(action_menu->menu_layer);
+        } else {
+            action_menu_close(action_menu, true);
+        }
+    }
+}
+
+static void _action_menu_click_provider(void *context) {
+    window_single_click_subscribe(BUTTON_ID_UP, _action_menu_select_prev);
+    window_single_click_subscribe(BUTTON_ID_DOWN, _action_menu_select_next);
+    window_single_click_subscribe(BUTTON_ID_SELECT, _action_menu_activate_item);
+    window_single_click_subscribe(BUTTON_ID_BACK, _action_menu_prev_level);
+}
+
+static void _action_menu_window_load(Window *window)
+{
+    ActionMenu *action_menu = (ActionMenu *)window;
+    ActionMenuConfig *config = &action_menu->config;
+    Layer* root_layer = window_get_root_layer(window);
+    GRect full_frame = layer_get_frame(root_layer);
+    window_set_background_color(window, GColorBlack);
+    window_set_click_config_provider_with_context(window, _action_menu_click_provider, action_menu);
+    
+    // Create the menu
+    action_menu->menu_layer = menu_layer_create(full_frame);
+    menu_layer_set_callbacks(action_menu->menu_layer, action_menu, (MenuLayerCallbacks) {
+        .get_num_rows = _get_num_rows_callback,
+        .draw_row = _draw_row_callback,
+        .get_cell_height = _get_cell_height_callback
+    });
+    menu_layer_set_normal_colors(action_menu->menu_layer, GColorClear, GColorClear);
+    menu_layer_set_highlight_colors(action_menu->menu_layer, GColorClear, GColorClear);
+#ifndef PBL_RECT
+    menu_layer_set_reload_behaviour(action_menu->menu_layer, MenuLayerReloadBehaviourOnSelection);
+#endif
+    layer_add_child(root_layer, menu_layer_get_layer(action_menu->menu_layer));
+
+    // Create the sidebar
+    GRect side_bar_frame = PBL_IF_RECT_ELSE(
+        GRect(0, 0, ACTION_MENU_SIDEBAR_SIZE, full_frame.size.h), /* rect */
+        
+        GRect(ACTION_MENU_SIDEBAR_SIZE, ACTION_MENU_SIDEBAR_SIZE,
+              full_frame.size.w - 2*ACTION_MENU_SIDEBAR_SIZE,
+              full_frame.size.h - 2*ACTION_MENU_SIDEBAR_SIZE) /* round */
+    );
+    Layer *side_bar_layer = layer_create(side_bar_frame);
+    layer_set_update_proc(side_bar_layer, _side_bar_update_proc);
+    layer_add_child(root_layer, side_bar_layer);
+}
+
+static void _action_menu_window_unload(Window *window)
 {
     // Unloaded
 }
 
-ActionMenu * action_menu_open(ActionMenuConfig * config)
+ActionMenu *action_menu_open(ActionMenuConfig *config)
 {
     ActionMenu *action_menu = (ActionMenu *)app_calloc(1, sizeof(ActionMenu));
-    action_menu->config = config;
+    memcpy(&action_menu->config, config, sizeof(ActionMenuConfig));
     action_menu->level_index = 0;
+    action_menu->cur_level = config->root_level;
+    action_menu->is_frozen = false;
     
-    Window *main = window_create();
-    main->user_data = action_menu;
-    
-    window_set_window_handlers(main, (WindowHandlers) {
-        .load = action_menu_window_load,
-        .unload = action_menu_window_unload,
+    window_ctor(&action_menu->window);
+    action_menu->window.user_data = action_menu;
+    window_set_window_handlers(&action_menu->window, (WindowHandlers) {
+        .load = _action_menu_window_load,
+        .unload = _action_menu_window_unload,
     });
-    
-    window_stack_push(main, true);
-    
-    app_event_loop();
+    window_stack_push(&action_menu->window, true);
     
     return action_menu;
 }
 
-void action_menu_freeze(ActionMenu * action_menu)
+void action_menu_freeze(ActionMenu *action_menu)
 {
-    
+    action_menu->is_frozen = true;
 }
 
-void action_menu_unfreeze(ActionMenu * action_menu)
+void action_menu_unfreeze(ActionMenu *action_menu)
 {
-    
+    action_menu->is_frozen = false;
 }
 
-void action_menu_set_result_window(ActionMenu * action_menu, Window * result_window)
+void action_menu_set_result_window(ActionMenu *action_menu, Window *result_window)
 {
     action_menu->result_window = result_window;
 }
 
-void action_menu_close(ActionMenu * action_menu, bool animated)
+void action_menu_close(ActionMenu *action_menu, bool animated)
 {
-    
+    window_destroy(&action_menu->window);
 }

--- a/rwatch/ui/action_menu.h
+++ b/rwatch/ui/action_menu.h
@@ -6,10 +6,10 @@
  * RebbleOS
  *
  * Author: Carson Katri <me@carsonkatri.com>.
+ * Author: Hermann Noll <hermann.noll@hotmail.com>
  */
 
 #include "librebble.h"
-#include "menu_layer.h"
 
 struct ActionMenuLevel;
 typedef struct ActionMenuLevel ActionMenuLevel;
@@ -50,83 +50,17 @@ typedef struct ActionMenuConfig
     ActionMenuAlign align;
 } ActionMenuConfig;
 
-char * action_menu_item_get_label(const ActionMenuItem * item);
-
-void * action_menu_item_get_action_data(const ActionMenuItem * item);
-
-ActionMenuLevel * action_menu_level_create(uint16_t max_items);
-
-void action_menu_level_set_display_mode(ActionMenuLevel * level, ActionMenuLevelDisplayMode display_mode);
-
-ActionMenuItem * action_menu_level_add_action(ActionMenuLevel * level, const char *label, ActionMenuPerformActionCb cb, void * action_data);
-
-ActionMenuItem * action_menu_level_add_child(ActionMenuLevel * level, ActionMenuLevel * child, const char * label);
-
-void action_menu_hierarchy_destroy(const ActionMenuLevel * root, ActionMenuEachItemCb each_cb, void * context);
-
-void * action_menu_get_context(ActionMenu * action_menu);
-
-ActionMenuLevel * action_menu_get_root_level(ActionMenu * action_menu);
-
-ActionMenu * action_menu_open(ActionMenuConfig * config);
-
-void action_menu_freeze(ActionMenu * action_menu);
-
-void action_menu_unfreeze(ActionMenu * action_menu);
-
-void action_menu_set_result_window(ActionMenu * action_menu, Window * result_window);
-
-void action_menu_close(ActionMenu * action_menu, bool animated);
-
-/*
-struct ActionMenuItem;
-struct ActionMenuItems;
-
-typedef struct ActionMenuItems* (*ActionMenuItemCallback)(const struct ActionMenuItem *item);
-
-typedef struct ActionMenuItem
-{
-    char *text;
-    char *sub_text;
-    MenuItemCallback on_select;
-} ActionMenuItem;
-
-#define ActionMenuItem(text, sub_text, image, on_select) ((MenuItem) { text, sub_text, image, on_select })
-
-typedef struct ActionMenuItems
-{
-    uint16_t count;
-    uint16_t capacity;
-    MenuItem *items;
-    
-    struct ActionMenuItems *back;
-    ActionMenuIndex back_index;
-} ActionMenuItems;
-
-ActionMenuItems* action_menu_items_create(uint16_t capacity);
-void action_menu_items_destroy(ActionMenuItems *items);
-void action_menu_items_add(ActionMenuItems *items, ActionMenuItem item);
-
-// called when back is pressed while in top menu
-typedef void (*ActionMenuExitCallback)(struct ActionMenu *menu, void *context);
-
-typedef struct ActionMenuCallbacks
-{
-    ActionMenuExitCallback on_action_menu_exit;
-} ActionMenuCallbacks;
-
-typedef struct ActionMenu
-{
-    ActionMenuItems *items;
-    MenuLayer *layer;
-    ActionMenuCallbacks callbacks;
-    void *context;
-} ActionMenu;
-
-
-ActionMenu* action_menu_create(GRect frame);
-void menu_destroy(Menu *menu);
-void menu_set_items(Menu *menu, MenuItems *items);
-Layer* menu_get_layer(Menu *menu);
-void menu_set_callbacks(Menu *menu, void *context, MenuCallbacks callbacks);
-void menu_set_click_config_onto_window(Menu *menu, struct Window *window);*/
+const char *action_menu_item_get_label(const ActionMenuItem *item);
+void *action_menu_item_get_action_data(const ActionMenuItem *item);
+ActionMenuLevel *action_menu_level_create(uint16_t max_items);
+void action_menu_level_set_display_mode(ActionMenuLevel *level, ActionMenuLevelDisplayMode display_mode);
+ActionMenuItem *action_menu_level_add_action(ActionMenuLevel *level, const char *label, ActionMenuPerformActionCb cb, void *action_data);
+ActionMenuItem *action_menu_level_add_child(ActionMenuLevel *level, ActionMenuLevel *child, const char *label);
+void action_menu_hierarchy_destroy(ActionMenuLevel *root, ActionMenuEachItemCb each_cb, void *context);
+void *action_menu_get_context(ActionMenu *action_menu);
+const ActionMenuLevel *action_menu_get_root_level(ActionMenu *action_menu);
+ActionMenu *action_menu_open(ActionMenuConfig *config);
+void action_menu_freeze(ActionMenu *action_menu);
+void action_menu_unfreeze(ActionMenu *action_menu);
+void action_menu_set_result_window(ActionMenu *action_menu, Window *result_window);
+void action_menu_close(ActionMenu *action_menu, bool animated);

--- a/rwatch/ui/layer/menu_layer.c
+++ b/rwatch/ui/layer/menu_layer.c
@@ -167,6 +167,8 @@ void menu_layer_set_selected_index(MenuLayer *menu_layer, MenuIndex index, MenuR
 {
     if (menu_index_compare(&menu_layer->selected, &index) != 0)
     {
+        if (menu_layer->callbacks.selection_will_change != NULL)
+            menu_layer->callbacks.selection_will_change(menu_layer, &index, &menu_layer->selected, menu_layer->context);
         menu_layer->selected = index;
 
         if (menu_layer->reload_behaviour == MenuLayerReloadBehaviourOnSelection)
@@ -174,6 +176,9 @@ void menu_layer_set_selected_index(MenuLayer *menu_layer, MenuIndex index, MenuR
         
         _menu_layer_update_scroll_offset(menu_layer, scroll_align, animated);
         layer_mark_dirty(menu_layer->layer);
+
+        if (menu_layer->callbacks.selection_changed != NULL)
+            menu_layer->callbacks.selection_changed(menu_layer, &index, &menu_layer->selected, menu_layer->context);
     }
 }
 

--- a/rwatch/ui/layer/menu_layer.h
+++ b/rwatch/ui/layer/menu_layer.h
@@ -67,11 +67,11 @@ typedef void (*MenuLayerDrawSeparatorCallback)(GContext *ctx, const Layer *layer
 
 typedef void (*MenuLayerSelectCallback)(struct MenuLayer *menu_layer, MenuIndex *cell_index, void *context);
 
-typedef void (*MenuLayerSelectionChangedCallback)(struct MenuLayer *menu_layer, MenuIndex new_index,
-                                                  MenuIndex old_index, void *context);
+typedef void (*MenuLayerSelectionChangedCallback)(struct MenuLayer *menu_layer, MenuIndex *new_index,
+                                                  MenuIndex *old_index, void *context);
 
 typedef void (*MenuLayerSelectionWillChangeCallback)(struct MenuLayer *menu_layer, MenuIndex *new_index,
-                                                     MenuIndex old_index, void *context);
+                                                     MenuIndex *old_index, void *context);
 
 typedef struct MenuLayerCallbacks
 {

--- a/rwatch/ui/window.c
+++ b/rwatch/ui/window.c
@@ -286,7 +286,7 @@ void window_destroy(Window *window)
     }
     
     /* Clean up the clink handler and remap back to our current window */
-    window_load_click_config(window);
+    window_load_click_config(window_stack_get_top_window());
     window_draw();
     window_dirty(true);
 }


### PR DESCRIPTION
So this is basically a full rewrite of `action_menu` already although I am still unsatisfied with the current state of it. As announced I will identify the remaining requirements and implement them before resuming here. What I did here was refactor the code, remove funky pointers and implemented some small details (e.g. freezing of user input). Rendering on chalk is still bad, multi-line item labels are not working (on all platforms), thin-mode is not implemented, etc. 

Also included here is a small fix for `menu_layer` I missed to put into #99. Also #106 is included here, but as soon as this is merged, git should be smart enough to remove it from here.