### PR TITLE
preparations for time sync with phone

### DIFF
--- a/hw/drivers/stm32_rtc/stm32_rtc.c
+++ b/hw/drivers/stm32_rtc/stm32_rtc.c
@@ -146,6 +146,22 @@ struct tm *hw_get_time(void)
     return &time_now;
 }
 
+void hw_set_time(struct tm *time_now)
+{
+    RTC_TimeTypeDef RTC_TimeStructure;
+    RTC_DateTypeDef RTC_DateStructure;
+
+    RTC_DateStructure.RTC_Year = time_now->tm_year - 2000 + 1900; // idk why but get_time does it too...
+    RTC_DateStructure.RTC_Month = time_now->tm_mon + 1; // same applies to this offset
+    RTC_DateStructure.RTC_Date = time_now->tm_mday;
+    RTC_TimeStructure.RTC_Hours = time_now->tm_hour;
+    RTC_TimeStructure.RTC_Minutes = time_now->tm_min;
+    RTC_TimeStructure.RTC_Seconds = time_now->tm_sec;
+
+    RTC_SetTime(RTC_Format_BIN, &RTC_TimeStructure);
+    RTC_SetDate(RTC_Format_BIN, &RTC_DateStructure);
+}
+
 void hw_set_alarm(struct tm alarm)
 {
 //     RTC_AlarmStructure.RTC_AlarmTime.RTC_H12     = RTC_H12_AM;
@@ -162,23 +178,6 @@ void hw_set_alarm(struct tm alarm)
 //     RTC_AlarmCmd(RTC_Alarm_A, ENABLE);
 //     RTC_ClearFlag(RTC_FLAG_ALRAF);
 }
-
-void hw_set_date_time(struct tm date_time)
-{
-//     RTC_DateStructure.RTC_Year = 0x13;
-//     RTC_DateStructure.RTC_Month = RTC_Month_January;
-//     RTC_DateStructure.RTC_Date = 0x11;
-//     RTC_DateStructure.RTC_WeekDay = RTC_Weekday_Saturday;
-//     RTC_SetDate(RTC_Format_BCD, &RTC_DateStructure);
-//
-//     RTC_TimeStructure.RTC_H12     = RTC_H12_AM;
-//     RTC_TimeStructure.RTC_Hours   = 0x05;
-//     RTC_TimeStructure.RTC_Minutes = 0x20;
-//     RTC_TimeStructure.RTC_Seconds = 0x00;
-//
-//     RTC_SetTime(RTC_Format_BCD, &RTC_TimeStructure);
-}
-
 
 void RTC_WKUP_IRQHandler(void)
 {

--- a/hw/drivers/stm32_rtc/stm32_rtc.h
+++ b/hw/drivers/stm32_rtc/stm32_rtc.h
@@ -23,6 +23,7 @@
 void rtc_init(void);
 void rtc_config(void);
 struct tm *hw_get_time(void);
+void hw_set_time(struct tm *time_now);
 
 #endif
 

--- a/hw/platform/tintin/tintin.c
+++ b/hw/platform/tintin/tintin.c
@@ -19,7 +19,6 @@
 #include "rebbleos.h"
 
 #include "stm32_power.h"
-#include "stm32_rtc.h"
 
 // extern void *strcpy(char *a2, const char *a1);
 

--- a/hw/platform/tintin/tintin.h
+++ b/hw/platform/tintin/tintin.h
@@ -34,13 +34,6 @@ uint8_t *hw_display_get_buffer(void);
 void hw_watchdog_init();
 void hw_watchdog_reset();
 
-void rtc_init();
-void rtc_config();
-void hw_get_time_str(char *buf);
-struct tm *hw_get_time(void);
-void rtc_set_timer_interval(TimeUnits tick_units);
-void rtc_disable_timer_interval(void);
-
 void hw_vibrate_init();
 void hw_vibrate_enable(uint8_t enabled);
 

--- a/rcore/rebble_time.h
+++ b/rcore/rebble_time.h
@@ -26,8 +26,10 @@ void rcore_localtime(struct tm *tm, time_t time);
 void rcore_time_ms(time_t *tutc, uint16_t *ms);
 TickType_t rcore_time_to_ticks(time_t t, uint16_t ms);
 size_t rcore_strftime(char* buffer, size_t maxSize, const char* format, const struct tm* tm);
+void rebble_time_set_tm(struct tm *time_now);
 
 // private
+void _sync_time_rtc(void);
 struct tm *rebble_time_get_tm(void);
 int pbl_clock_is_24h_style();
 uint16_t pbl_time_deprecated(time_t *tloc);


### PR DESCRIPTION
This PR adds a method in the HAL to set the RTC and adds a thin abstraction layer that allows to set the OS time and the RTC in one go.