### PR TITLE
Improve PBL_BW subtitle readability

### DIFF
--- a/hw/platform/tintin/tintin.c
+++ b/hw/platform/tintin/tintin.c
@@ -307,7 +307,7 @@ void hw_vibrate_enable(uint8_t enabled) {
 #define JEDEC_RDSR_BUSY 0x01
 
 #define JEDEC_IDCODE_MICRON_N25Q032A11 0x20BB16 /* bianca / qemu / ev2_5 */
-
+#define JEDEC_IDCODE_MICRON_N25Q064A11 0x20BB17 /* v1_5 */
 static uint8_t _hw_flash_txrx(uint8_t c) {
     while (!(SPI1->SR & SPI_SR_TXE))
         ;
@@ -406,8 +406,8 @@ void hw_flash_init(void) {
     _hw_flash_enable(0);
     
     printf("tintin flash: JEDEC ID %08lx\n", part_id);
-    
-    if (part_id != JEDEC_IDCODE_MICRON_N25Q032A11) {
+
+    if (part_id != JEDEC_IDCODE_MICRON_N25Q032A11 && part_id != JEDEC_IDCODE_MICRON_N25Q064A11) {
         panic("tintin flash: unsupported part ID");
     }
     

--- a/rwatch/ui/layer/menu_layer.c
+++ b/rwatch/ui/layer/menu_layer.c
@@ -524,7 +524,11 @@ void menu_cell_basic_draw_ex(GContext *ctx, GRect frame, const char *title,
     if (subtitle)
     {
         has_subtitle = true;
+        #ifdef PBL_BW
+        GFont font = fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD);
+        #else
         GFont font = fonts_get_system_font(FONT_KEY_GOTHIC_18);
+        #endif
         GRect subtitle_rect;
         subtitle_rect = GRect(x, frame.size.h / 2 - 2,
                               frame.size.w - x - MENU_CELL_PADDING, frame.size.h);


### PR DESCRIPTION
PBL_BW subtitle font is too thin, causes the shading to cut into the letters too much and makes readability much worse than it could be. This will just make that font bold (Until better solution of setting menu selections to black instead of shading is implemented correctly, currently makes icons hidden too as they're black)