### PR TITLE
Cleanup a few prints

### DIFF
--- a/Apps/System/test.c
+++ b/Apps/System/test.c
@@ -29,12 +29,12 @@ static Time s_last_time;
 
 static void play_click_handler(ClickRecognizerRef recognizer, void *context)
 {
-    printf("UP");
+    printf("UP\n");
 }
 
 static void pause_click_handler(ClickRecognizerRef recognizer, void *context)
 {
-    printf("DOWN");
+    printf("DOWN\n");
 }
 
 static void click_config_provider(void *context)

--- a/rwatch/ui/layer/action_bar_layer.c
+++ b/rwatch/ui/layer/action_bar_layer.c
@@ -115,7 +115,6 @@ static void draw(Layer *layer, GContext *context)
         if (action_bar->icons[i] != NULL) {
             // Draw the icon:
             GSize icon_size = action_bar->icons[i]->raw_bitmap_size;
-            printf(action_bar->icons[i]);
 #ifdef PBL_RECT
             graphics_draw_bitmap_in_rect(context, action_bar->icons[i], GRect(full_bounds.size.w - icon_size.w - 2, y - (increment / 2) - (icon_size.h / 2), icon_size.w, icon_size.h));
 #else

--- a/rwatch/ui/layer/status_bar_layer.c
+++ b/rwatch/ui/layer/status_bar_layer.c
@@ -131,7 +131,6 @@ static void _draw(Layer *layer, GContext *context)
     if (status_bar->text == NULL) {
         char time_string[8];
         rcore_strftime(time_string, 8, "%R", &status_bar->last_time);
-        printf("%s", time_string);
 
         graphics_draw_text(context, time_string, text_font, text_bounds,
                                GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, 0);


### PR DESCRIPTION
Removes the time being printed every statur bar redraw,
removes random characters being printed when drawing action bar icons,
add newline for up and down print in test app.