### PR TITLE
Calendar and Timeline

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,5 +3,6 @@ The RebbleOS Authors are:
   Barry Carter <barry.carter@gmail.com>
   Joshua Wise <joshua@joshuawise.com>
   NiVZ <paulniven@aol.com>
+  Carson Katri <carson.katri@gmail.com>
 
 If you contribute code to RebbleOS, please add your name to this file.

--- a/Apps/System/systemapp.c
+++ b/Apps/System/systemapp.c
@@ -100,8 +100,9 @@ static void systemapp_window_load(Window *window)
 
     menu_set_click_config_onto_window(s_menu, window);
 
-    MenuItems *items = menu_items_create(5);
+    MenuItems *items = menu_items_create(6);
     menu_items_add(items, MenuItem("Watchfaces", "All your faces", RESOURCE_ID_CLOCK, watch_list_item_selected));
+    menu_items_add(items, MenuItem("Timeline", "RWS Goes Live", RESOURCE_ID_CLOCK, app_item_selected));
     menu_items_add(items, MenuItem("Settings", "Config", RESOURCE_ID_SPANNER, settings_item_selected));
     menu_items_add(items, MenuItem("Tests", NULL, RESOURCE_ID_CLOCK, run_test_item_selected));
     menu_items_add(items, MenuItem("Notifications", NULL, RESOURCE_ID_SPEECH_BUBBLE, notification_item_selected));

--- a/Apps/System/timeline.c
+++ b/Apps/System/timeline.c
@@ -181,11 +181,11 @@ static void menu_draw_row_callback(GContext* ctx, const Layer *cell_layer, MenuI
   if (timeline) {
     // TIMELINE UI
     if (index->row == selected.row) {
-      s_timeline->callback_data = (void *) selected.row;
+      s_timeline->callback_data = &selected.row;
     }
   } else {
     // CALENDAR UI
-    s_timeline->callback_data = (void *) index->row;
+    s_timeline->callback_data = &index->row;
   }
 }
 
@@ -205,7 +205,6 @@ static void timeline_window_load(Window *window) {
   timeline_events_add(s_events, TimelineEvent("RebbleOS\n7:00pm", "This is a ways away", Date(23, 1, 2018), RESOURCE_ID_SPEECH_BUBBLE, GColorIslamicGreen));
 
   s_day_count = days_in_month(s_month, s_year);
-  printf("\n\nDAYS IN MONTH: %d\n\n", s_day_count);
   s_day_offset = zeller(0, s_month - 1, s_year);
 
   s_menu_layer = menu_layer_create(bounds);

--- a/Apps/System/timeline.c
+++ b/Apps/System/timeline.c
@@ -117,11 +117,8 @@ static void timeline_update_proc(Layer *layer, GContext *ctx) {
 
   if (timeline) {
     // TIMELINE UI
-    graphics_context_set_fill_color(ctx, GColorRed);
+    graphics_context_set_fill_color(ctx, event->color);
     graphics_fill_rect(ctx, GRect(frame.size.w - 25, 0, 25, frame.size.h), 0, GCornerNone);
-
-    graphics_context_set_fill_color(ctx, GColorRed);
-
     n_gpath_fill(ctx, n_gpath_create(&triangle));
 
     graphics_draw_text(ctx, event->name, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(frame.origin.x, frame.origin.y, frame.size.w - 25, 36), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
@@ -151,7 +148,7 @@ static void timeline_update_proc(Layer *layer, GContext *ctx) {
       for (int i = 0; i < ((TimelineEvents *) s_events)->count; i++) {
         Date date = s_events->events[i].date;
         if ((int)date.date == (day - (s_day_offset - 1)) && (int)date.month == s_month && (int)date.year == s_year) {
-          graphics_context_set_fill_color(ctx, GColorRed);
+          graphics_context_set_fill_color(ctx, s_events->events[i].color);
           graphics_context_set_text_color(ctx, GColorWhite);
           break;
         } else {
@@ -159,7 +156,7 @@ static void timeline_update_proc(Layer *layer, GContext *ctx) {
           graphics_context_set_text_color(ctx, GColorBlack);
         }
       }
-      graphics_context_set_stroke_color(ctx, day - s_day_offset == s_selected ? GColorRed : GColorWhite);
+      graphics_context_set_stroke_color(ctx, day - s_day_offset == s_selected ? GColorBlack : GColorWhite);
 
       if (day < s_day_offset) {
         graphics_context_set_fill_color(ctx, GColorWhite);
@@ -203,9 +200,9 @@ static void timeline_window_load(Window *window) {
   GRect bounds = layer_get_frame(window_layer);
 
   s_events = timeline_events_create(3);
-  timeline_events_add(s_events, TimelineEvent("RWS Launch\n5:00pm", "Organizer: Katharine Berry\nInvitees: Rebblers\n\nEveryone will be there. You should too!", Date(1, 1, 2018), RESOURCE_ID_CLOCK));
-  timeline_events_add(s_events, TimelineEvent("Meeting\n6:00pm", "Other content", Date(10, 1, 2018), RESOURCE_ID_SPANNER));
-  timeline_events_add(s_events, TimelineEvent("RebbleOS\n7:00pm", "This is a ways away", Date(23, 1, 2018), RESOURCE_ID_SPEECH_BUBBLE));
+  timeline_events_add(s_events, TimelineEvent("RWS Launch\n5:00pm", "Organizer: Katharine Berry\nInvitees: Rebblers\n\nEveryone will be there. You should too!", Date(1, 1, 2018), RESOURCE_ID_CLOCK, GColorRed));
+  timeline_events_add(s_events, TimelineEvent("Meeting\n6:00pm", "Other content", Date(10, 1, 2018), RESOURCE_ID_SPANNER, GColorVividCerulean));
+  timeline_events_add(s_events, TimelineEvent("RebbleOS\n7:00pm", "This is a ways away", Date(23, 1, 2018), RESOURCE_ID_SPEECH_BUBBLE, GColorIslamicGreen));
 
   s_day_count = days_in_month(s_month, s_year);
   printf("\n\nDAYS IN MONTH: %d\n\n", s_day_count);

--- a/Apps/System/timeline.c
+++ b/Apps/System/timeline.c
@@ -1,0 +1,255 @@
+/* timeline.c
+ *
+ * The Rebble Timeline
+ *
+ * RebbleOS
+ *
+ * Author: Carson Katri <carson.katri@gmail.com>.
+ */
+
+#include "rebbleos.h"
+#include "timeline.h"
+#include "librebble.h"
+#include "platform_res.h"
+
+static const char* const s_months[] = {
+	"January", "February", "March", "April", "May", "June", "July",
+	"August", "September","October", "November", "December"
+};
+
+static const char* const s_weekdays[] = {
+	"S", "M", "T", "W", "T", "F", "S"
+};
+
+TimelineEvents *s_events;
+int s_selected;
+Layer *s_timeline;
+
+int zeller(int day_of_month, int month, int year) {
+  int m = month;
+  if (m <= 1) {
+    m += 13;
+  } else {
+    m += 1;
+  }
+  int y = year;
+  if (month <= 1) {
+    y--;
+  }
+  return (day_of_month + ((13 * (m + 1)) / 5) + y + (y / 4) - (y / 100) + (y / 400)) % 7;
+}
+
+int days_in_month(int month, int year) {
+  static const int days[2][13] = {
+    { 0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 },
+    { 0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
+  };
+  int leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+  return days[leap][month];
+}
+
+int s_month = 1;
+int s_year = 2018;
+int s_day_count = 31;
+int s_day_offset = 0;
+
+bool timeline = false;
+
+static Window *s_main_window;
+static MenuLayer *s_menu_layer;
+
+TimelineEvents* timeline_events_create(uint16_t capacity) {
+    TimelineEvents *result = (TimelineEvents *) app_calloc(1, sizeof(TimelineEvents));
+    result->capacity = capacity;
+    result->count = 0;
+    if (capacity > 0)
+        result->events = (TimelineEvent *) app_calloc(capacity, sizeof(TimelineEvent));
+
+    return result;
+}
+
+void timeline_events_destroy(TimelineEvents *events) {
+    if (!events)
+        return;
+
+    if (events->capacity > 0)
+        app_free(events->events);
+
+    app_free(events);
+}
+
+void timeline_events_add(TimelineEvents *events, TimelineEvent event) {
+    if (events->capacity == events->count)
+        return; // TODO: should we grow, or report error here?
+
+    events->events[events->count++] = event;
+}
+
+static uint16_t menu_get_num_sections_callback(MenuLayer *menu_layer, void *data) {
+  return 1;
+}
+
+static uint16_t menu_get_num_rows_callback(MenuLayer *menu_layer, uint16_t section_index, void *data) {
+  return timeline ? s_events->count : 31;
+}
+
+static int16_t menu_get_header_height_callback(MenuLayer *menu_layer, uint16_t section_index, void *data) {
+  return 0;
+}
+
+static void menu_draw_header_callback(GContext* ctx, const Layer *cell_layer, uint16_t section_index, void *data) {
+
+}
+
+static n_GPathInfo triangle = {
+  .num_points = 3,
+  .points = (GPoint []) {{DISPLAY_COLS - 25, 5}, {DISPLAY_COLS - 25, 25}, {DISPLAY_COLS - 30, 15}}
+};
+
+static void timeline_update_proc(Layer *layer, GContext *ctx) {
+  int row = (int) s_timeline->callback_data;
+  TimelineEvent *event = &s_events->events[row];
+
+  GRect frame = layer->bounds;
+
+  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_fill_rect(ctx, frame, 0, GCornerNone);
+
+  if (timeline) {
+    // TIMELINE UI
+    graphics_context_set_fill_color(ctx, GColorRed);
+    graphics_fill_rect(ctx, GRect(frame.size.w - 25, 0, 25, frame.size.h), 0, GCornerNone);
+
+    graphics_context_set_fill_color(ctx, GColorRed);
+
+    n_gpath_fill(ctx, n_gpath_create(&triangle));
+
+    graphics_draw_text(ctx, event->name, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(frame.origin.x, frame.origin.y, frame.size.w - 25, 36), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
+    graphics_draw_text(ctx, event->description, fonts_get_system_font(FONT_KEY_GOTHIC_18), GRect(frame.origin.x, frame.origin.y + 36, frame.size.w - 25, frame.size.h - 36), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
+
+    GBitmap *gbitmap = gbitmap_create_with_resource((int) event->image);
+    graphics_draw_bitmap_in_rect(ctx, gbitmap, GRect(frame.size.w - 23, 5, 22, 22));
+  } else {
+    // CALENDAR UI
+    graphics_draw_text(ctx, s_months[s_month - 1], fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(frame.origin.x, frame.origin.y, frame.size.w, 36), GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
+
+    // EACH WEEK
+    int week_count = (int) s_day_count / 7;
+
+    double day_offset = DISPLAY_COLS / 7;
+    double week_offset = day_offset;
+
+    for (int weekday = 0; weekday < 7; weekday++) {
+      graphics_context_set_text_color(ctx, GColorBlack);
+      graphics_draw_text(ctx, s_weekdays[weekday], fonts_get_system_font(FONT_KEY_GOTHIC_09), GRect(day_offset * weekday, 24, day_offset, week_offset), GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
+    }
+
+    for (int day = 0; day < s_day_count + s_day_offset; day++) {
+      int week = (int) day / 7;
+
+      // Check if this date has an event
+      for (int i = 0; i < ((TimelineEvents *) s_events)->count; i++) {
+        Date date = s_events->events[i].date;
+        if ((int)date.date == (day - (s_day_offset - 1)) && (int)date.month == s_month && (int)date.year == s_year) {
+          graphics_context_set_fill_color(ctx, GColorRed);
+          graphics_context_set_text_color(ctx, GColorWhite);
+          break;
+        } else {
+          graphics_context_set_fill_color(ctx, GColorWhite);
+          graphics_context_set_text_color(ctx, GColorBlack);
+        }
+      }
+      graphics_context_set_stroke_color(ctx, day - s_day_offset == s_selected ? GColorRed : GColorWhite);
+
+      if (day < s_day_offset) {
+        graphics_context_set_fill_color(ctx, GColorWhite);
+        graphics_context_set_stroke_color(ctx, GColorWhite);
+        graphics_context_set_text_color(ctx, GColorLightGray);
+      }
+
+      GRect rect = GRect((day_offset * (day % 7)), (week_offset * week) + 36, day_offset, week_offset);
+      graphics_fill_rect(ctx, rect, 0, GCornerNone);
+      graphics_draw_rect(ctx, rect, 0, GCornerNone);
+
+      char buf[] = "00000000000";
+      snprintf(buf, sizeof(buf), "%d", (day > s_day_offset - 1) ? day + 1 - s_day_offset : days_in_month(s_month - 1 < 1 ? 12 : s_month - 1, s_year) - s_day_offset + day + 1);
+      graphics_draw_text(ctx, buf, fonts_get_system_font(FONT_KEY_GOTHIC_14), rect, GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
+    }
+  }
+}
+
+static void menu_draw_row_callback(GContext* ctx, const Layer *cell_layer, MenuIndex *index, void *data) {
+  MenuIndex selected = menu_layer_get_selected_index(s_menu_layer);
+  s_selected = selected.row;
+  if (timeline) {
+    // TIMELINE UI
+    if (index->row == selected.row) {
+      s_timeline->callback_data = (void *) selected.row;
+    }
+  } else {
+    // CALENDAR UI
+    s_timeline->callback_data = (void *) index->row;
+  }
+}
+
+static void menu_select_callback(MenuLayer *menu_layer, MenuIndex *index, void *data) {
+  // Show an info page or something...
+  timeline = !timeline;
+  layer_mark_dirty(s_timeline);
+}
+
+static void timeline_window_load(Window *window) {
+  Layer *window_layer = window_get_root_layer(window);
+  GRect bounds = layer_get_frame(window_layer);
+
+  s_events = timeline_events_create(3);
+  timeline_events_add(s_events, TimelineEvent("RWS Launch\n5:00pm", "Organizer: Katharine Berry\nInvitees: Rebblers\n\nEveryone will be there. You should too!", Date(1, 1, 2018), RESOURCE_ID_CLOCK));
+  timeline_events_add(s_events, TimelineEvent("Meeting\n6:00pm", "Other content", Date(10, 1, 2018), RESOURCE_ID_SPANNER));
+  timeline_events_add(s_events, TimelineEvent("RebbleOS\n7:00pm", "This is a ways away", Date(23, 1, 2018), RESOURCE_ID_SPEECH_BUBBLE));
+
+  s_day_count = days_in_month(s_month, s_year);
+  printf("\n\nDAYS IN MONTH: %d\n\n", s_day_count);
+  s_day_offset = zeller(0, s_month - 1, s_year);
+
+  s_menu_layer = menu_layer_create(bounds);
+  menu_layer_set_callbacks(s_menu_layer, NULL, (MenuLayerCallbacks) {
+    .get_num_sections = menu_get_num_sections_callback,
+    .get_num_rows = menu_get_num_rows_callback,
+    .get_header_height = menu_get_header_height_callback,
+    .draw_header = menu_draw_header_callback,
+    .draw_row = menu_draw_row_callback,
+    .select_click = menu_select_callback,
+  });
+
+  GRect frame = window_get_root_layer(s_main_window)->bounds;
+  s_timeline = layer_create_with_data(frame, sizeof(int));
+  layer_set_update_proc(s_timeline, timeline_update_proc);
+  layer_add_child(menu_layer_get_layer(s_menu_layer), s_timeline);
+
+  menu_layer_set_click_config_onto_window(s_menu_layer, window);
+
+  layer_add_child(window_layer, menu_layer_get_layer(s_menu_layer));
+}
+
+static void timeline_window_unload(Window *window) {
+  menu_layer_destroy(s_menu_layer);
+}
+
+static void timeline_init() {
+  s_main_window = window_create();
+  window_set_window_handlers(s_main_window, (WindowHandlers) {
+    .load = timeline_window_load,
+    .unload = timeline_window_unload,
+  });
+  window_stack_push(s_main_window, true);
+}
+
+static void timeline_deinit() {
+  window_destroy(s_main_window);
+}
+
+void timeline_main(void) {
+  timeline_init();
+  app_event_loop();
+  timeline_deinit();
+}

--- a/Apps/System/timeline.h
+++ b/Apps/System/timeline.h
@@ -1,0 +1,49 @@
+#pragma once
+/* timeline.h
+ *
+ * The Rebble Timeline
+ *
+ * RebbleOS
+ *
+ * Author: Carson Katri <carson.katri@gmail.com>.
+ */
+
+#include "display.h"
+#include "backlight.h"
+#include "rebbleos.h"
+#include "menu.h"
+
+struct TimelineEvent;
+struct TimelineEvents;
+struct Date;
+
+typedef struct Date {
+  int *date;
+  int *month;
+  int *year;
+} Date;
+
+#define Date(date, month, year) ((Date) { (int *) date, (int *) month, (int *) year })
+
+typedef struct TimelineEvent {
+  char *name;
+  char *description;
+  Date date;
+  uint16_t *image;
+} TimelineEvent;
+
+#define TimelineEvent(name, description, date, image) ((TimelineEvent) { name, description, date, (int *) image })
+
+typedef struct TimelineEvents {
+  TimelineEvent *events;
+  uint16_t capacity;
+  uint16_t count;
+} TimelineEvents;
+
+TimelineEvents* timeline_events_create(uint16_t capacity);
+void timeline_events_destroy(TimelineEvents *events);
+void timeline_events_add(TimelineEvents *events, TimelineEvent event);
+
+static MenuItems* timeline_event_selected(const MenuItem *item);
+
+void timeline_main(void);

--- a/Apps/System/timeline.h
+++ b/Apps/System/timeline.h
@@ -33,7 +33,7 @@ typedef struct TimelineEvent {
   GColor color;
 } TimelineEvent;
 
-#define TimelineEvent(name, description, date, image, color) ((TimelineEvent) { name, description, date, (int *) image, color })
+#define TimelineEvent(name, description, date, image, color) ((TimelineEvent) { name, description, date, (uint16_t *) image, color })
 
 typedef struct TimelineEvents {
   TimelineEvent *events;

--- a/Apps/System/timeline.h
+++ b/Apps/System/timeline.h
@@ -30,9 +30,10 @@ typedef struct TimelineEvent {
   char *description;
   Date date;
   uint16_t *image;
+  GColor color;
 } TimelineEvent;
 
-#define TimelineEvent(name, description, date, image) ((TimelineEvent) { name, description, date, (int *) image })
+#define TimelineEvent(name, description, date, image, color) ((TimelineEvent) { name, description, date, (int *) image, color })
 
 typedef struct TimelineEvents {
   TimelineEvent *events;

--- a/config.mk
+++ b/config.mk
@@ -142,6 +142,7 @@ SRCS_all += Watchfaces/nivz.c
 SRCS_all += Apps/System/systemapp.c
 SRCS_all += Apps/System/menu.c
 SRCS_all += Apps/System/testapp.c
+SRCS_all += Apps/System/timeline.c
 
 SRCS_all += Apps/System/test.c
 SRCS_all += Apps/System/notification.c


### PR DESCRIPTION
This adds `timeline.c` and `timeline.h` files. These contain a combined timeline and calendar example app. The calendar uses Zeller's congruence to show the dates on the correct days of the week:

![screen shot 2018-07-28 at 9 24 47 am](https://user-images.githubusercontent.com/13581484/43356978-2fa63c4c-9248-11e8-8a8c-b2c383550916.png)
The colored background means there is an event on that date. Each `TimelineEvent` has it's own `char *name`, `char *description`, `Date date`, `uint16_t *image`, and `GColor color`. The black border is the selected date. Press the select button to view the timeline:
![screen shot 2018-07-27 at 9 48 48 pm](https://user-images.githubusercontent.com/13581484/43351864-dcecdb16-91e6-11e8-9ca7-4194d115708a.png)

They're both built on the same `menu_layer`. Right now I have it show January, but you can select any `s_month` and `s_year`. Eventually this will link with bluetooth to show any timeline events. But for now, they're static.