### PR TITLE
shorter display isr to avoid missed systick

### DIFF
--- a/hw/platform/snowy_family/snowy_display.c
+++ b/hw/platform/snowy_family/snowy_display.c
@@ -7,65 +7,6 @@
  * Author: Barry Carter <barry.carter@gmail.com>
  */
 
-#include "stm32f4xx.h"
-#include "stdio.h"
-#include "string.h"
-#include "display.h"
-#include "log.h"
-#include "vibrate.h"
-#include "snowy_display.h"
-#include <stm32f4xx_spi.h>
-#include <stm32f4xx_tim.h>
-#include "stm32_power.h"
-#include "stm32_spi.h"
-#include "platform_config.h"
-#include "rebble_memory.h"
-#include "resource.h"
-
-#define ROW_LENGTH    DISPLAY_COLS
-#define COLUMN_LENGTH DISPLAY_ROWS
-static uint8_t _frame_buffer[DISPLAY_ROWS * DISPLAY_COLS] CCRAM;
-static uint8_t _column_buffer[COLUMN_LENGTH];
-static uint8_t _display_ready;
-
-void _snowy_display_start_frame(uint8_t xoffset, uint8_t yoffset);
-uint8_t _snowy_display_wait_FPGA_ready(void);
-void _snowy_display_splash(uint8_t scene);
-void _snowy_display_full_init(void);
-void _snowy_display_program_FPGA(void);
-void _snowy_display_send_frame(void);
-void _snowy_display_cs(uint8_t enabled);
-uint8_t _snowy_display_FPGA_reset(uint8_t mode);
-void _snowy_display_reset(uint8_t enabled);
-void _snowy_display_SPI_start(void);
-void _snowy_display_SPI_end(void);
-void _snowy_display_drawscene(uint8_t scene);
-void _snowy_display_init_intn(void);
-void _snowy_display_dma_send(uint8_t *data, uint32_t len);
-void _snowy_display_next_column(uint8_t col_index);
-void _snowy_display_init_dma(void);
-static void _spi_tx_done(void);
-
-
-typedef struct {
-    GPIO_TypeDef *port_display;
-    uint32_t clock_display;
-    uint16_t pin_reset;
-    uint16_t pin_cs;   
-    uint16_t pin_miso;
-    uint16_t pin_mosi;
-    uint16_t pin_sck;
-    
-    // inputs
-    uint16_t pin_reset_done;
-    uint16_t pin_intn;    
-} display_t;
-
-
-// pointer to the place in flash where the FPGA image resides
-// extern unsigned char fpga_address; // _binary_Resources_FPGA_4_3_snowy_dumped_bin_start;
-// extern unsigned char fpga_size; //binary_Resources_FPGA_4_3_snowy_dumped_bin_size;
-
 /*
  * Generic functional notes 
  * 
@@ -88,7 +29,72 @@ typedef struct {
  */
 
 
-// Display configuration for the Pebble TIME
+#include "stm32f4xx.h"
+#include "stdio.h"
+#include "string.h"
+#include "display.h"
+#include "log.h"
+#include "vibrate.h"
+#include "snowy_display.h"
+#include <stm32f4xx_spi.h>
+#include <stm32f4xx_tim.h>
+#include "stm32_power.h"
+#include "stm32_spi.h"
+#include "platform_config.h"
+#include "rebble_memory.h"
+#include "resource.h"
+
+/* display command types */
+#define DISPLAY_CTYPE_NULL        0x00
+#define DISPLAY_CTYPE_PARAM       0x01
+#define DISPLAY_CTYPE_DISPLAY_OFF 0x02
+#define DISPLAY_CTYPE_DISPLAY_ON  0x03
+#define DISPLAY_CTYPE_SCENE       0x04
+/* in full fat mode */
+#define DISPLAY_CTYPE_FRAME       0x05
+
+
+/* NOTE this is pinned to CCRAM on supported devices.
+ * This does mean we can't (not that we could) dma from CCRAM to the SPI.
+ * It's an unsupported hardware config for stm32 at least
+ */
+static uint8_t _frame_buffer[DISPLAY_ROWS * DISPLAY_COLS] CCRAM;
+static uint8_t _column_buffer[DISPLAY_ROWS];
+static uint8_t _display_ready;
+
+void _snowy_display_start_frame(uint8_t xoffset, uint8_t yoffset);
+uint8_t _snowy_display_wait_FPGA_ready(void);
+void _snowy_display_splash(uint8_t scene);
+void _snowy_display_full_init(void);
+void _snowy_display_program_FPGA(void);
+void _snowy_display_send_frame(void);
+void _snowy_display_cs(uint8_t enabled);
+uint8_t _snowy_display_FPGA_reset(uint8_t mode);
+void _snowy_display_reset(uint8_t enabled);
+void _snowy_display_SPI_start(void);
+void _snowy_display_SPI_end(void);
+void _snowy_display_drawscene(uint8_t scene);
+void _snowy_display_init_intn(void);
+void _snowy_display_dma_send(uint8_t *data, uint32_t len);
+void _snowy_display_next_column(uint8_t col_index);
+void _snowy_display_init_dma(void);
+static void _spi_tx_done(void);
+
+typedef struct {
+    GPIO_TypeDef *port_display;
+    uint32_t clock_display;
+    uint16_t pin_reset;
+    uint16_t pin_cs;   
+    uint16_t pin_miso;
+    uint16_t pin_mosi;
+    uint16_t pin_sck;
+    
+    /* inputs */
+    uint16_t pin_reset_done;
+    uint16_t pin_intn;    
+} display_t;
+
+/* Display configuration for the Pebble TIME */
 static const display_t display = {
     .port_display    = GPIOG,
     .clock_display   = RCC_AHB1Periph_GPIOG,
@@ -100,7 +106,6 @@ static const display_t display = {
     .pin_reset_done  = GPIO_Pin_9,
     .pin_intn        = GPIO_Pin_10,
 };
-
 
 static const stm32_spi_config_t _spi6_config = {
     .spi               = SPI6,
@@ -139,9 +144,8 @@ static stm32_spi_t _spi6 = {
     &_spi6_dma, /* dma */
 };
 
-void _spi_tx_done(void);
 
-// SPI6 	DMA2 	DMA Stream 5 	DMA Channel 1 	DMA Stream 6 	DMA Channel 0
+/* SPI6     DMA2    DMA Stream 5    DMA Channel 1   DMA Stream 6    DMA Channel 0 */
 STM32_SPI_MK_TX_IRQ_HANDLER(&_spi6, 2, 5, _spi_tx_done)
 
 /*
@@ -151,16 +155,13 @@ void hw_display_init(void)
 {
     _display_ready = 0;
 
-    // init display variables
+    /* init interupt pin, cs and reset */
     stm32_power_request(STM32_POWER_APB2, RCC_APB2Periph_SYSCFG);
     stm32_power_request(STM32_POWER_AHB1, RCC_AHB1Periph_GPIOG);
 
-    //GPIO_InitTypeDef gpio_init_structure;
     GPIO_InitTypeDef gpio_init_disp;
     GPIO_InitTypeDef gpio_init_disp_o;
     
-    
-    // init the portG display pins (inputs)
     gpio_init_disp.GPIO_Mode = GPIO_Mode_IN;
     gpio_init_disp.GPIO_Pin =  display.pin_reset_done;
     gpio_init_disp.GPIO_PuPd = GPIO_PuPd_NOPULL;
@@ -168,7 +169,6 @@ void hw_display_init(void)
     gpio_init_disp.GPIO_OType = GPIO_OType_OD;
     GPIO_Init(display.port_display, &gpio_init_disp);
 
-    // init the portG display pins (inputs)
     gpio_init_disp.GPIO_Mode = GPIO_Mode_IN;
     gpio_init_disp.GPIO_Pin =  display.pin_intn;
     gpio_init_disp.GPIO_PuPd = GPIO_PuPd_NOPULL;
@@ -176,17 +176,18 @@ void hw_display_init(void)
     gpio_init_disp.GPIO_OType = GPIO_OType_OD;
     GPIO_Init(GPIOG, &gpio_init_disp);
     
-    // init the portG display pins (outputs)
+    /* init the portG display pins (outputs) */
     gpio_init_disp_o.GPIO_Mode = GPIO_Mode_OUT;
     gpio_init_disp_o.GPIO_Pin =  display.pin_reset | display.pin_cs;
     gpio_init_disp_o.GPIO_PuPd = GPIO_PuPd_NOPULL;
     gpio_init_disp_o.GPIO_Speed = GPIO_Speed_100MHz;
     gpio_init_disp_o.GPIO_OType = GPIO_OType_PP;
-    GPIO_Init(display.port_display, &gpio_init_disp_o);       
+    GPIO_Init(display.port_display, &gpio_init_disp_o);
         
-    // start SPI
+    /* start SPI hardware */
     stm32_spi_init_device(&_spi6);
     
+    /* Boot the display  */
     hw_display_start();
 
     stm32_power_release(STM32_POWER_APB2, RCC_APB2Periph_SYSCFG);
@@ -195,7 +196,6 @@ void hw_display_init(void)
     return;
 }
 
-
 /*
  * We use the Done INTn for the display. This is asserted
  * after every successful command write. I.t. 0x5 to star a frame 
@@ -203,18 +203,18 @@ void hw_display_init(void)
  */
 void _snowy_display_init_intn(void)
 {
-    // Snowy uses two interrupts for the display
-    // Done (G10) signals the drawing is done
-    // INTn (G9) I suspect is for device readyness after flash
-    //
-    // PinSource9 uses IRQ (EXTI9_5_IRQn) and 10 uses (EXTI15_10_IRQn)
+    /* Snowy uses two interrupts for the display
+     * Done (G10) signals the drawing is done
+     * INTn (G9) I suspect is for device readyness after flash
+     * PinSource9 uses IRQ (EXTI9_5_IRQn) and 10 uses (EXTI15_10_IRQn)
+     */
     EXTI_InitTypeDef EXTI_InitStruct;
     NVIC_InitTypeDef NVIC_InitStruct;
     
     stm32_power_request(STM32_POWER_APB2, RCC_APB2Periph_SYSCFG);
     stm32_power_request(STM32_POWER_AHB1, RCC_AHB1Periph_GPIOG);
     
-    // Wait for external interrupts when the FPGA is done with a command
+    /* Wait for external interrupts when the FPGA is done with a command */
     SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOG, EXTI_PinSource10);
     
     EXTI_InitStruct.EXTI_Line = EXTI_Line10;
@@ -223,7 +223,6 @@ void _snowy_display_init_intn(void)
     EXTI_InitStruct.EXTI_Trigger = EXTI_Trigger_Falling;
     EXTI_Init(&EXTI_InitStruct);
 
-    // display used PinSource10 which is connected to EXTI15_10
     NVIC_InitStruct.NVIC_IRQChannel = EXTI15_10_IRQn;
     NVIC_InitStruct.NVIC_IRQChannelPreemptionPriority = 7;  // must be > 5
     NVIC_InitStruct.NVIC_IRQChannelSubPriority = 0x00;
@@ -236,14 +235,12 @@ void _snowy_display_init_intn(void)
 
 static void _snowy_display_request_clocks()
 {
-//     stm32_power_request(STM32_POWER_AHB1, RCC_AHB1Periph_DMA2);
     stm32_power_request(STM32_POWER_APB2, RCC_APB2Periph_SPI6);
     stm32_power_request(STM32_POWER_AHB1, RCC_AHB1Periph_GPIOG);
 }
 
 static void _snowy_display_release_clocks()
 {
-//     stm32_power_release(STM32_POWER_AHB1, RCC_AHB1Periph_DMA2);
     stm32_power_release(STM32_POWER_APB2, RCC_APB2Periph_SPI6);
     stm32_power_release(STM32_POWER_AHB1, RCC_AHB1Periph_GPIOG);
 }
@@ -253,26 +250,14 @@ static void _snowy_display_release_clocks()
  */
 static void _spi_tx_done(void)
 {
-    static uint8_t col_index = 0;
-
-    // if we are finished sending  each column, then reset and stop
-    if (col_index < ROW_LENGTH - 1)
-    {
-        ++col_index;
-        // ask for convert and display the next column
-        _snowy_display_next_column(col_index);
-        return;
-    }
-    // done. We are still in control of the SPI select, so lets let go
-    col_index = 0;    
-    
-    _snowy_display_cs(0);
-    _display_ready = 1;
-    
-    /* request_clocks in _snowy_display_start_frame */
-    _snowy_display_release_clocks();
-    display_done_ISR(0);
+    display_done_isr(0);
 }
+
+/* 
+ * Process the ISR from the rtos task.
+ * We are drawing rows/cols here.
+ * Setup the next row/col and start dma
+ */
 
 /*
  * Interrupt handler for the INTn Done interrupt on the FPGA
@@ -299,7 +284,6 @@ void _snowy_display_cs(uint8_t enabled)
     
     stm32_power_request(STM32_POWER_AHB1, display.clock_display);
 
-    // CS bit is inverted
     if (!enabled)
         GPIO_SetBits(display.port_display, display.pin_cs);
     else
@@ -313,9 +297,8 @@ void _snowy_display_cs(uint8_t enabled)
  */
 void _snowy_display_next_column(uint8_t col_index)
 {   
-    // set the content
     scanline_convert(_column_buffer, _frame_buffer, col_index);
-    stm32_spi_send_dma(&_spi6, _column_buffer, COLUMN_LENGTH);
+    stm32_spi_send_dma(&_spi6, _column_buffer, DISPLAY_ROWS);
 }
 
 /*
@@ -332,7 +315,7 @@ uint8_t _snowy_display_FPGA_reset(uint8_t mode)
 
     _snowy_display_request_clocks();
 
-    // Pull out reset
+    /* Pull out reset */
     _snowy_display_cs(mode);
     delay_large(1);
     _snowy_display_reset(0);
@@ -343,9 +326,10 @@ uint8_t _snowy_display_FPGA_reset(uint8_t mode)
     _snowy_display_reset(1);
     delay_us(1);
     
-    // The real pebble at this point will pull reset done once it has reset
-    // it also (probably dangerously) "just works" without.
-    // it probably isn't the danger zone, but it's the highway
+    /* The real pebble at this point will pull reset done once it has reset
+     * it also (probably dangerously) "just works" without.
+     * it probably isn't the danger zone, but it's the highway
+     */
     while(1)
     {
         g9 = GPIO_ReadInputDataBit(display.port_display, display.pin_reset_done);
@@ -385,7 +369,7 @@ void _snowy_display_reset(uint8_t enabled)
     stm32_power_release(STM32_POWER_AHB1, display.clock_display);
 }
 
-// SPI Command related
+/* SPI Command related */
 
 /*
  * Shortcut function to address the display device using its
@@ -394,7 +378,7 @@ void _snowy_display_reset(uint8_t enabled)
 void _snowy_display_SPI_start(void)
 {
     _snowy_display_cs(1);
-    delay_us(100);
+    delay_us(10);
 }
 
 /*
@@ -412,13 +396,12 @@ void _snowy_display_SPI_end(void)
 void _snowy_display_start_frame(uint8_t xoffset, uint8_t yoffset)
 {
     _snowy_display_request_clocks();
-//     stm32_power_request(_spi6.config->spi_periph_bus, _spi6.config->spi_clock);
     
     _snowy_display_cs(1);
     delay_us(10);
     stm32_spi_write(&_spi6, DISPLAY_CTYPE_FRAME); // Frame Begin
     _snowy_display_cs(0);
-    delay_us(250);
+    delay_us(25);
 
     _display_ready = 0;
 
@@ -432,14 +415,14 @@ void _snowy_display_start_frame(uint8_t xoffset, uint8_t yoffset)
  */
 void _snowy_display_send_frame()
 {
-//     return _snowy_display_send_frame_slow();
     _snowy_display_cs(1);
-    delay_us(80);
-    // send over DMA
-    // we are only going to send one single column at a time
-    // the dma engine completion will trigger the next lot of data to go
+    delay_us(40);
+    /* send over DMA
+     * we are only going to send one single column at a time
+     * the dma engine completion will trigger the next lot of data to go
+     */
     _snowy_display_next_column(0);
-    // we return immediately and let the system take care of the rest
+    /* we return immediately and let the system take care of the rest */
 }
 
 /*
@@ -457,7 +440,7 @@ void _snowy_display_send_frame_slow()
     
     _snowy_display_cs(1);
     
-    // send via standard SPI
+    /* send via standard SPI */
     for(uint8_t x = 0; x < DISPLAY_COLS; x++)
     {
         scanline_convert(_column_buffer, _frame_buffer, x);
@@ -479,7 +462,7 @@ uint8_t _snowy_display_wait_FPGA_ready(void)
     
     GPIO_InitTypeDef gpio_init_disp;
     
-    // init the portG display pins (inputs)
+    /* init the portG display pins (inputs) */
     gpio_init_disp.GPIO_Mode = GPIO_Mode_IN;
     gpio_init_disp.GPIO_Pin =  display.pin_intn;
     gpio_init_disp.GPIO_PuPd = GPIO_PuPd_NOPULL;
@@ -494,7 +477,7 @@ uint8_t _snowy_display_wait_FPGA_ready(void)
             char *err = "Timed out waiting for ready";
             DRV_LOG("FPGA", APP_LOG_LEVEL_ERROR, err);
             return 0;
-        }        
+        }
         delay_us(100);
     }
     DRV_LOG("FPGA", APP_LOG_LEVEL_DEBUG, "FPGA Ready");
@@ -533,8 +516,9 @@ void _snowy_display_full_init(void)
     _snowy_display_send_frame_slow();
 */
 
-    // enable interrupts now we have the splash up
-    // Interrupt handler is in with bluetooth :/
+    /* enable interrupts now we have the splash up
+     * Interrupt handler is in with bluetooth :/
+     */
     _snowy_display_init_intn();   
     _snowy_display_release_clocks();
 }
@@ -549,7 +533,7 @@ void _snowy_display_program_FPGA(void)
     _snowy_display_request_clocks();
     _snowy_display_cs(1);
     
-    // Do this with good ol manual SPI for reliability
+    /* Do this with good ol manual SPI for reliability */
     for (uint32_t i = 0; i < (uint32_t)DISPLAY_FPGA_SIZE; i++)
     {
         stm32_spi_write(&_spi6, *(fpga_blob + i));
@@ -562,7 +546,7 @@ void _snowy_display_program_FPGA(void)
 }
 
 
-// API (barely) implementation
+/* Public interface */
 
 /*
  * When in bootloader mode, we can command the screen to power on
@@ -597,6 +581,29 @@ uint8_t hw_display_is_ready()
     return _display_ready;
 }
 
+uint8_t hw_display_process_isr(void)
+{
+    static uint16_t col_index = 0;
+
+    if (col_index < DISPLAY_COLS - 1)
+    {
+        ++col_index;
+        /* ask for convert and display the next column */
+        _snowy_display_next_column(col_index);
+        return 0;
+    }
+    /* if we are finished sending each column, then reset and stop */
+    col_index = 0;    
+    
+    /* done. We are still in control of the SPI select, so lets let go */
+    _snowy_display_cs(0);
+    _display_ready = 1;
+    
+    /* request_clocks in _snowy_display_start_frame */
+    _snowy_display_release_clocks();
+    return 1;
+}
+
 /*
  * Reset the display
  * Needs work before it works (ahem) after first boot
@@ -616,7 +623,7 @@ void hw_display_start(void)
 }
 
 
-// Util
+/* Util. Moveme. Nukeme. */ 
 
 void delay_us(uint16_t us)
 {

--- a/hw/platform/snowy_family/snowy_display.h
+++ b/hw/platform/snowy_family/snowy_display.h
@@ -11,32 +11,18 @@
 
 #define MAX_FRAMEBUFFER_SIZE DISPLAY_ROWS * DISPLAY_COLS
 
-// display command types
-#define DISPLAY_CTYPE_NULL        0x00
-#define DISPLAY_CTYPE_PARAM       0x01
-#define DISPLAY_CTYPE_DISPLAY_OFF 0x02
-#define DISPLAY_CTYPE_DISPLAY_ON  0x03
-#define DISPLAY_CTYPE_SCENE       0x04
-// in full fat mode
-#define DISPLAY_CTYPE_FRAME       0x05
-
-
 void hw_display_init(void);
-void hw_display_deinit(void);
-int hw_display_test(void);
 void hw_display_reset(void);
 void hw_display_start(void);
-void hw_backlight_init(void);
-void hw_backlight_set(uint16_t val);
 uint8_t hw_display_is_ready();
 uint8_t *hw_display_get_buffer(void);
+uint8_t hw_display_process_isr(void);
 
 void hw_display_on();
 void hw_display_start_frame(uint8_t xoffset, uint8_t yoffset);
 
 // TODO: move to scanline
 void scanline_convert(uint8_t *out_buffer, uint8_t *frame_buffer, uint8_t column_index);
-// void scanline_rgb888pixel_to_frambuffer(UG_S16 x, UG_S16 y, UG_COLOR c);
 
 void delay_us(uint16_t us);
 void delay_large(uint16_t ms);

--- a/rcore/display.h
+++ b/rcore/display.h
@@ -6,28 +6,10 @@
  * Author: Barry Carter <barry.carter@gmail.com>
  */
 
-#include "FreeRTOS.h"
 #include <stdbool.h>
 
-#define DISPLAY_MODE_BOOTLOADER      0
-#define DISPLAY_MODE_FULLFAT         1
-
-// commands for draw
-#define DISPLAY_CMD_DRAW             1
-#define DISPLAY_CMD_RESET            2
-#define DISPLAY_CMD_DONE             3
-
-
-/* XXX this is not portable yet, and really needs to get split into hw/ */
-#ifdef STM32F2XX
-#include "stm32f2xx.h"
-#else
-#include "stm32f4xx.h"
-#endif
-
-
 uint8_t display_init(void);
-void display_done_ISR(uint8_t cmd);
+void display_done_isr(uint8_t cmd);
 void display_reset(uint8_t enabled);
 void display_draw(void);
 uint8_t *display_get_buffer(void);


### PR DESCRIPTION
display isr was taking a long time to render a frame causing the occasional systick irq to not be serviced leading to clock drift.
This patch hands the isr back to the servicing rtos thread after each row/col draw