### PR TITLE
Handles for resources. Tidy up of res

### DIFF
--- a/rcore/log.h
+++ b/rcore/log.h
@@ -19,6 +19,30 @@
             log_printf_to_ar(module_, "APP", lvl_, __FILE__, __LINE__, fmt_, ##__VA_ARGS__)
 
 
+#define _LOG_NONE  0
+#define _LOG_DEBUG 1
+#define _LOG_INFO  2
+#define _LOG_ERROR 4
+
+#define RBL_LOG_LEVEL_ALL (_LOG_DEBUG | _LOG_INFO | _LOG_ERROR)
+#define RBL_LOG_LEVEL_DEBUG (_LOG_DEBUG | _LOG_INFO | _LOG_ERROR)
+#define RBL_LOG_LEVEL_INFO (_LOG_INFO | _LOG_ERROR)
+#define RBL_LOG_LEVEL_ERROR _LOG_ERROR
+#define RBL_LOG_LEVEL_NONE _LOG_NONE
+
+#define __LOG_AR(name_, type_, log_type_, fmt_, ...) \
+        log_printf_to_ar(name_, type_, log_type_, __FILE__, __LINE__, fmt_, ##__VA_ARGS__)
+
+#define LOG_INFO(fmt_, ...) \
+        if (LOG_LEVEL & _LOG_INFO) \
+            __LOG_AR(MODULE_NAME, MODULE_TYPE, APP_LOG_LEVEL_INFO, fmt_, ##__VA_ARGS__)
+#define LOG_DEBUG(fmt_, ...) \
+        if (LOG_LEVEL & _LOG_DEBUG) \
+            __LOG_AR(MODULE_NAME, MODULE_TYPE, APP_LOG_LEVEL_DEBUG, fmt_, ##__VA_ARGS__)
+#define LOG_ERROR(fmt_, ...) \
+        if (LOG_LEVEL & _LOG_ERROR) \
+            __LOG_AR(MODULE_NAME, MODULE_TYPE, APP_LOG_LEVEL_ERROR, fmt_, ##__VA_ARGS__)
+
 typedef enum LogLevel {
     APP_LOG_LEVEL_ERROR,
     APP_LOG_LEVEL_WARNING,

--- a/rcore/resource.h
+++ b/rcore/resource.h
@@ -7,17 +7,19 @@
  */
 
 #include "graphics_reshandle.h"
+typedef struct ResHandleFileHeader ResHandleFileHeader;
 
 struct file;
 
 uint8_t resource_init();
-void resource_load_id_system(uint16_t resource_id, uint8_t *buffer);
 ResHandle resource_get_handle_system(uint16_t resource_id);
-ResHandle resource_get_handle_app(uint32_t resource_id, const struct file *file);
-void resource_load_app(ResHandle resource_handle, uint8_t *buffer, const struct file *file);
-void resource_load_system(ResHandle resource_handle, uint8_t *buffer);
+ResHandle resource_get_handle(uint32_t resource_id);
 size_t resource_size(ResHandle handle);
-uint8_t *resource_fully_load_id_app(uint16_t resource_id, const struct file *file);
-uint8_t *resource_fully_load_id_system(uint16_t resource_id);
-uint8_t *resource_fully_load_res_system(ResHandle res_handle);
-uint8_t *resource_fully_load_res_app(ResHandle res_handle, const struct file *file);
+size_t resource_load_byte_range(ResHandle res_handle, uint32_t start_offset, uint8_t *buffer, size_t num_bytes);
+void resource_load(ResHandle resource_handle, uint8_t *buffer, size_t max_length);
+void resource_load_file(ResHandleFileHeader resource_header_handle, uint8_t *buffer, size_t max_length, const struct file *file);
+
+uint8_t *resource_fully_load_id_system(uint32_t resource_id);
+uint8_t *resource_fully_load_id_app(uint32_t resource_id);
+uint8_t *resource_fully_load_id_app_file(uint32_t resource_id, const struct file *file, size_t *loaded_size);
+uint8_t *resource_fully_load_resource(ResHandle res_handle, const struct file *file, size_t *loaded_size);

--- a/rwatch/graphics/font_loader.c
+++ b/rwatch/graphics/font_loader.c
@@ -106,11 +106,17 @@ GFont fonts_get_system_font_by_resource_id(uint32_t resource_id)
 /*
  * Load a custom font
  */
-GFont *fonts_load_custom_font(ResHandle *handle, const struct file* file)
-{   
-    uint8_t *buffer = resource_fully_load_res_app(*handle, file);
+GFont fonts_load_custom_font(ResHandle handle, const struct file* file)
+{
+    uint8_t *buffer = resource_fully_load_resource(handle, file, NULL);
+    
+    return (GFont)buffer;
+}
 
-    return (GFont *)buffer;
+GFont fonts_load_custom_font_proxy(ResHandle handle)
+{
+    App *app = appmanager_get_current_app();
+    return (GFont)fonts_load_custom_font(handle, &app->resource_file);
 }
 
 /*

--- a/rwatch/graphics/font_loader.h
+++ b/rwatch/graphics/font_loader.h
@@ -8,6 +8,7 @@
 
 void fonts_resetcache();
 GFont fonts_get_system_font(const char *key);
-GFont *fonts_load_custom_font(ResHandle *handle, const struct file* file);
+GFont fonts_load_custom_font(ResHandle handle, const struct file* file);
 void fonts_unload_custom_font(GFont font);
-GFont *fonts_load_custom_font_proxy(ResHandle *handle);
+GFont fonts_load_custom_font_proxy(ResHandle handle);
+

--- a/rwatch/graphics/gbitmap.c
+++ b/rwatch/graphics/gbitmap.c
@@ -11,8 +11,6 @@
 #include "png.h"
 #include "ngfxwrap.h"
 
-extern uint8_t *resource_fully_load_id_app(uint16_t, const struct file *file);
-
 /*
  * Load a resource into the GBitmap by resource id
  */
@@ -21,23 +19,22 @@ GBitmap *gbitmap_create_with_resource(uint32_t resource_id)
     uint8_t *png_data = resource_fully_load_id_system(resource_id);
     ResHandle res_handle = resource_get_handle_system(resource_id);
     size_t png_data_size = resource_size(res_handle);
-    
+
     if (!png_data)
         return NULL;
-        
+
     return gbitmap_create_from_png_data(png_data, png_data_size);
 }
 
 GBitmap *gbitmap_create_with_resource_app(uint32_t resource_id, const struct file *file)
 {
-    uint8_t *png_data = (uint8_t*)resource_fully_load_id_app(resource_id, file);
-    ResHandle res_handle = resource_get_handle_app(resource_id, file);
-    size_t png_data_size = resource_size(res_handle);
-    
+    size_t png_size;
+    uint8_t *png_data = (uint8_t*)resource_fully_load_id_app_file(resource_id, file, &png_size);
+
     if (!png_data)
         return NULL;
-        
-    return gbitmap_create_from_png_data(png_data, png_data_size);
+
+    return gbitmap_create_from_png_data(png_data, png_size);
 }
 
 /*
@@ -57,7 +54,7 @@ GBitmap *gbitmap_create_from_png_data(uint8_t *png_data, size_t png_data_size)
     GBitmap *bitmap = (GBitmap*)app_malloc(sizeof(GBitmap));
 
     png_to_gbitmap(bitmap, png_data, png_data_size);
-    
+
     return bitmap;
 }
 

--- a/rwatch/graphics/graphics.c
+++ b/rwatch/graphics/graphics.c
@@ -10,18 +10,26 @@
 #include "png.h"
 #include "graphics_wrapper.h"
 
-GRect _jimmy_layer_offset(n_GContext *ctx, n_GRect rect)
+/* Configure Logging */
+#define MODULE_NAME "grphcs"
+#define MODULE_TYPE "SYS"
+#define LOG_LEVEL RBL_LOG_LEVEL_INFO //RBL_LOG_LEVEL_ERROR
+static GBitmap _fb_gbitmap;
+
+static GRect _jimmy_layer_offset(n_GContext *ctx, n_GRect rect)
 {
     // jimmy the offsets for the layer before we ask ngfx to draw it
     return (GRect) {
         .origin.x = rect.origin.x + ctx->offset.origin.x,
         .origin.y = rect.origin.y + ctx->offset.origin.y, 
-        .size.w = (rect.size.w > ctx->offset.size.w ? ctx->offset.size.w : rect.size.w), 
-        .size.h = (rect.size.h > ctx->offset.size.h ? ctx->offset.size.h : rect.size.h), 
+        /* Seems like clipping to the parent frame 
+         *(likely the screen size in most cases) isn't the right thing */
+        .size.w = rect.size.w, //(rect.size.w > ctx->offset.size.w ? ctx->offset.size.w : rect.size.w), 
+        .size.h = rect.size.h, // > ctx->offset.size.h ? ctx->offset.size.h : rect.size.h), 
     };
 }
 
-n_GPoint _jimmy_layer_point_offset(n_GContext *ctx, n_GPoint point)
+static n_GPoint _jimmy_layer_point_offset(n_GContext *ctx, n_GPoint point)
 {
     // jimmy the offsets for the layer before we ask ngfx to draw it
     return (GPoint) {
@@ -59,6 +67,7 @@ void graphics_draw_text(
     const n_GTextOverflowMode overflow_mode, const n_GTextAlignment alignment,
     n_GTextAttributes * text_attributes)
 {
+    LOG_DEBUG("text");
     n_graphics_draw_text(ctx, text, font, _jimmy_layer_offset(ctx, box),
                             overflow_mode, alignment,
                             text_attributes);
@@ -66,6 +75,7 @@ void graphics_draw_text(
 
 void graphics_draw_bitmap_in_rect(GContext *ctx, const GBitmap *bitmap, GRect rect)
 {
+    LOG_DEBUG("gbir");
     GRect offsetted = _jimmy_layer_offset(ctx, rect);
     n_graphics_draw_bitmap_in_rect(ctx, bitmap, offsetted);
 }
@@ -73,34 +83,44 @@ void graphics_draw_bitmap_in_rect(GContext *ctx, const GBitmap *bitmap, GRect re
 
 void graphics_draw_pixel(n_GContext * ctx, n_GPoint p)
 {
+    LOG_DEBUG("dip");
     n_graphics_draw_pixel(ctx, _jimmy_layer_point_offset(ctx, p));
 
 }
 
 void graphics_draw_rect(n_GContext * ctx, n_GRect rect, uint16_t radius, n_GCornerMask mask)
 {
+    LOG_DEBUG("rect");
     n_graphics_draw_rect(ctx, _jimmy_layer_offset(ctx, rect), radius, mask);
 }
 
 
-
 GBitmap *graphics_capture_frame_buffer(n_GContext *context)
 {
-    // TODO Honestly not entirely sure what is expected here
     // rbl_lock_frame_buffer
-    return (GBitmap *)display_get_buffer();
+    if (!_fb_gbitmap.addr)
+    {
+        _fb_gbitmap.addr = display_get_buffer();
+        _fb_gbitmap.raw_bitmap_size.w = DISPLAY_COLS;
+        _fb_gbitmap.raw_bitmap_size.h = DISPLAY_ROWS;
+        _fb_gbitmap.row_size_bytes = DISPLAY_COLS;
+        _fb_gbitmap.bounds = GRect(0, DISPLAY_COLS, 0, DISPLAY_ROWS);
+        _fb_gbitmap.format = n_GBitmapFormat8Bit;
+    }
+    return &_fb_gbitmap;
 }
 
 GBitmap *graphics_capture_frame_buffer_format(n_GContext *context, GBitmap format)
 {
-    // TODO Honestly not entirely sure what is expected here
     // rbl_lock_frame_buffer
+    LOG_DEBUG("fb lock");
     return (GBitmap *)display_get_buffer();
 }
 
 void graphics_release_frame_buffer(n_GContext *context, GBitmap *bitmap)
 {
     // rbl_unlock_frame_buffer
+    LOG_DEBUG("fb unlock");
 }
 
 

--- a/rwatch/graphics/graphics_reshandle.h
+++ b/rwatch/graphics/graphics_reshandle.h
@@ -1,17 +1,15 @@
 #pragma once
 /* graphics_reshandle.h
- * routines for [...]
  * libRebbleOS
  *
  * Author: Barry Carter <barry.carter@gmail.com>
  */
 
-typedef struct ResHandle
-{
-    uint32_t index;
-    uint32_t offset;
-    uint32_t size;
-    uint32_t crc;
-} ResHandle;
+/**
+ * @brief A handle to a resource. This isn't anything you can use in an app
+ * it is an opaque handle to a resouce.
+ */
+typedef size_t ResHandle;
 
-ResHandle resource_get_handle(uint16_t resource_id);
+//ResHandle resource_get_handle(uint16_t resource_id);
+

--- a/rwatch/graphics/libros_graphics.h
+++ b/rwatch/graphics/libros_graphics.h
@@ -25,8 +25,6 @@ void gpath_move_to_app(n_GPath * path, n_GPoint offset);
 // (VoidFunc)graphics_draw_round_rect_app,
 
 // n_GPath * gpath_create_app(n_GPathInfo * path_info);
-n_GRect _jimmy_layer_offset(n_GContext *ctx, n_GRect rect);
-n_GPoint _jimmy_layer_point_offset(n_GContext *ctx, n_GPoint point);
 
 GBitmap *graphics_capture_frame_buffer(n_GContext *context);
 GBitmap *graphics_capture_frame_buffer_format(n_GContext *context, GBitmap format);


### PR DESCRIPTION
Handles are now passed around for a resource.
A handle is the address of the resource header.
The handle is then used to load the resource header and then the resource. This is a little slower as we are loading twice, but safe(ish) and leak free to pass to apps.